### PR TITLE
fix!: Remove Python 3.7 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ keywords = ["Api", "Gift cards", "Rewards", "Incentives", "Tremendous"]
 include = ["tremendous/py.typed"]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 
 urllib3 = ">= 1.25.3"
 python-dateutil = ">=2.8.2"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 
 from setuptools import setup, find_packages
 
-PYTHON_REQUIRES = ">=3.7"
+PYTHON_REQUIRES = ">=3.8"
 
 data = {}
 root = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
[3.7 has been EOL](https://endoflife.date/python) for more than 1 year and the `setup-python` GH action [no longer works](https://github.com/tremendous-rewards/tremendous-python/actions/runs/15492312863/job/43620532602) 