### PR TITLE
fix: unlock `urllib3` dependency to support recent releases

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
-urllib3 >= 1.25.3, < 2.1.0
+urllib3 >= 2.1.0, < 3.0.0
 pydantic >= 2
 typing-extensions >= 4.7.1

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     url="https://github.com/tremendous-rewards/tremendous-python",
     keywords=["Api", "Gift cards", "Rewards", "Incentives", "Tremendous"],
     install_requires=[
-        "urllib3 >= 1.25.3, < 2.1.0",
+        "urllib3 >= 2.1.0, < 3.0.0",
         "python-dateutil",
         "pydantic >= 2",
         "typing-extensions >= 4.7.1",


### PR DESCRIPTION
Should close the vulnerability that was fixed on [2.5.0](https://github.com/urllib3/urllib3/releases/tag/2.5.0).