### PR TITLE
chore: Increase Dependabot cooldown to 7 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      default-days: 2
+      default-days: 7
 
 
   - package-ecosystem: "pip"
@@ -13,4 +13,4 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      default-days: 2
+      default-days: 7


### PR DESCRIPTION
Given the recent supply chain attacks, this raises Dependabot's minimum package age to seven days before version update PRs are opened.

Existing stricter cooldowns stay in place, so major and minor updates that already waited longer continue to do so.