### PR TITLE
chore: drop EOL Python versions (3.8, 3.9), test against 3.10–3.14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: '3.14'
+          python-version: '3.x'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: '3.x'
+          python-version: '3.14'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ keywords = ["Api", "Gift cards", "Rewards", "Incentives", "Tremendous"]
 include = ["tremendous/py.typed"]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.11"
 
 urllib3 = ">= 2.1.0"
 python-dateutil = ">=2.8.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ keywords = ["Api", "Gift cards", "Rewards", "Incentives", "Tremendous"]
 include = ["tremendous/py.typed"]
 
 [tool.poetry.dependencies]
-python = "^3.11"
+python = "^3.10"
 
 urllib3 = ">= 2.1.0"
 python-dateutil = ">=2.8.2"


### PR DESCRIPTION
Python 3.8 and 3.9 are end-of-life. Dropping them from the CI matrix unblocks pending Dependabot PRs (notably flake8 >=7.3.0) that require a Python 3.11+ runtime.

The new test matrix covers 3.10–3.14. The `python` constraint in `pyproject.toml` is bumped to `^3.10` to match. Release builds use `3.x` to always pick the latest stable release automatically.