### PR TITLE
chore: correct typo in .openapi-generator-ignore for test-requirements.txt

### DIFF
--- a/.openapi-generator-ignore
+++ b/.openapi-generator-ignore
@@ -36,6 +36,6 @@ README.md
 setup.py
 setup.cfg
 requirements.txt
-text-requirements.txt
+test-requirements.txt
 pyproject.toml
 .gitignore


### PR DESCRIPTION
The file was listed as `text-requirements.txt` (missing the `s`), so the ignore rule never matched and the generator was silently overwriting `test-requirements.txt` on every SDK regeneration.

This caused the scheduled `update-sdk` workflow to open PRs reverting Dependabot version bumps to dev dependencies — most recently PR #118, which reverted the flake8 `>=7.3.0` bump we just merged.