### PR TITLE
chore: remove unused dev dependencies from requirements manifests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,6 @@ typing-extensions = ">=4.7.1"
 
 [tool.poetry.dev-dependencies]
 pytest = ">=7.2.1"
-types-python-dateutil = ">=2.8.19.14"
-mypy = "1.4.1"
 
 
 [build-system]
@@ -30,40 +28,3 @@ build-backend = "setuptools.build_meta"
 
 [tool.pylint.'MESSAGES CONTROL']
 extension-pkg-whitelist = "pydantic"
-
-[tool.mypy]
-files = [
-  "tremendous",
-  "test", # hand-written tests
-]
-# TODO: enable "strict" once all these individual checks are passing
-# strict = true
-
-# List from: https://mypy.readthedocs.io/en/stable/existing_code.html#introduce-stricter-options
-warn_unused_configs = true
-warn_redundant_casts = true
-warn_unused_ignores = true
-
-## Getting these passing should be easy
-strict_equality = true
-strict_concatenate = true
-
-## Strongly recommend enabling this one as soon as you can
-check_untyped_defs = true
-
-## These shouldn't be too much additional work, but may be tricky to
-## get passing if you use a lot of untyped libraries
-disallow_subclassing_any = true
-disallow_untyped_decorators = true
-disallow_any_generics = true
-
-### These next few are various gradations of forcing use of type annotations
-#disallow_untyped_calls = true
-#disallow_incomplete_defs = true
-#disallow_untyped_defs = true
-#
-### This one isn't too hard to get passing, but return on investment is lower
-#no_implicit_reexport = true
-#
-### This one can be tricky to get passing if you use a lot of untyped libraries
-#warn_return_any = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 python_dateutil >= 2.5.3
-setuptools >= 82.0.1
 urllib3 >= 2.1.0, < 3.0.0
 pydantic >= 2
 typing-extensions >= 4.7.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,5 @@
 pytest >= 7.2.1
 pytest-cov >= 7.1.0
-tox >= 4.54.0
 flake8 >= 7.3.0
 types-python-dateutil >= 2.8.19.14
 mypy >= 1.5

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,1 @@
 pytest >= 7.2.1
-types-python-dateutil >= 2.8.19.14
-mypy >= 1.5

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,4 @@
 pytest >= 7.2.1
 pytest-cov >= 7.1.0
-flake8 >= 7.3.0
 types-python-dateutil >= 2.8.19.14
 mypy >= 1.5

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,3 @@
 pytest >= 7.2.1
-pytest-cov >= 7.1.0
 types-python-dateutil >= 2.8.19.14
 mypy >= 1.5


### PR DESCRIPTION
Several dependencies in `requirements.txt` and `test-requirements.txt` were never actually used — either in CI or anywhere in the project. This removes them to avoid confusion and unnecessary Dependabot noise.

Removed:

- `setuptools` from `requirements.txt` — a build tool, not a runtime SDK dependency. It's already declared correctly under `[build-system].requires` in `pyproject.toml`, and the release workflow installs it from there via `python -m build`. Users installing the SDK don't need it pinned as a runtime dep.
- `tox` from `test-requirements.txt` — no `tox.ini` or `[tool.tox]` config exists anywhere in the repo, and CI never invokes it. Carried over from the generator's default template.
- `flake8` from `test-requirements.txt` — installed in CI but no workflow step actually runs it.
- `pytest-cov` from `test-requirements.txt` — no coverage reporting is configured or run.
- `mypy` and `types-python-dateutil` from `test-requirements.txt` — not run in CI. `types-python-dateutil` is only useful as a mypy stub, so it goes with it.