### PR TITLE
fix: tolerate unknown enum values in API responses

### DIFF
--- a/templates/python/model_generic.mustache
+++ b/templates/python/model_generic.mustache
@@ -1,0 +1,405 @@
+from __future__ import annotations
+import pprint
+import re  # noqa: F401
+import json
+import warnings  # noqa: F401
+
+{{#vendorExtensions.x-py-other-imports}}
+{{{.}}}
+{{/vendorExtensions.x-py-other-imports}}
+{{#vendorExtensions.x-py-model-imports}}
+{{{.}}}
+{{/vendorExtensions.x-py-model-imports}}
+from typing import Optional, Set
+from typing_extensions import Self
+
+{{#hasChildren}}
+{{#discriminator}}
+{{! If this model is a super class, importlib is used. So import the necessary modules for the type here. }}
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+{{#mappedModels}}
+    from {{packageName}}.models.{{model.classFilename}} import {{modelName}}
+{{/mappedModels}}
+
+{{/discriminator}}
+{{/hasChildren}}
+class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}):
+    """
+    {{#description}}{{{description}}}{{/description}}{{^description}}{{{classname}}}{{/description}}
+    """ # noqa: E501
+{{#vars}}
+    {{name}}: {{{vendorExtensions.x-py-typing}}}
+{{/vars}}
+{{#isAdditionalPropertiesTrue}}
+    additional_properties: Dict[str, Any] = {}
+{{/isAdditionalPropertiesTrue}}
+    __properties: ClassVar[List[str]] = [{{#allVars}}"{{baseName}}"{{^-last}}, {{/-last}}{{/allVars}}]
+{{#vars}}
+    {{#vendorExtensions.x-regex}}
+
+    @field_validator('{{{name}}}')
+    def {{{name}}}_validate_regular_expression(cls, value):
+        """Validates the regular expression"""
+        {{^required}}
+        if value is None:
+            return value
+
+        {{/required}}
+        {{#required}}
+        {{#isNullable}}
+        if value is None:
+            return value
+
+        {{/isNullable}}
+        {{/required}}
+        if not re.match(r"{{{.}}}", value{{#vendorExtensions.x-modifiers}} ,re.{{{.}}}{{/vendorExtensions.x-modifiers}}):
+            raise ValueError(r"must validate the regular expression {{{vendorExtensions.x-pattern}}}")
+        return value
+    {{/vendorExtensions.x-regex}}
+    {{#isEnum}}
+
+    @field_validator('{{{name}}}')
+    def {{{name}}}_validate_enum(cls, value):
+        """Validates the enum"""
+        {{^required}}
+        if value is None:
+            return value
+
+        {{/required}}
+        {{#required}}
+        {{#isNullable}}
+        if value is None:
+            return value
+
+        {{/isNullable}}
+        {{/required}}
+        {{! Unknown enum values warn instead of raising, so responses parse when the API adds values this SDK version doesn't know about yet. }}
+        {{#isContainer}}
+        {{#isArray}}
+        for i in value:
+            if i not in set([{{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}}]):
+                warnings.warn(f"Unrecognized value '{i}' in enum list field `{{{name}}}`; known values are ({{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}}). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
+        {{/isArray}}
+        {{#isMap}}
+        for i in value.values():
+            if i not in set([{{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}}]):
+                warnings.warn(f"Unrecognized value '{i}' in enum map field `{{{name}}}`; known values are ({{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}}). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
+        {{/isMap}}
+        {{/isContainer}}
+        {{^isContainer}}
+        if value not in set([{{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}}]):
+            warnings.warn(f"Unrecognized value '{value}' for enum field `{{{name}}}`; known values are ({{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}}). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
+        {{/isContainer}}
+        return value
+    {{/isEnum}}
+{{/vars}}
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        validate_assignment=True,
+        protected_namespaces=(),
+    )
+
+
+{{#hasChildren}}
+{{#discriminator}}
+    # JSON field name that stores the object type
+    __discriminator_property_name: ClassVar[str] = '{{discriminator.propertyBaseName}}'
+
+    # discriminator mappings
+    __discriminator_value_class_map: ClassVar[Dict[str, str]] = {
+        {{#mappedModels}}'{{{mappingName}}}': '{{{modelName}}}'{{^-last}},{{/-last}}{{/mappedModels}}
+    }
+
+    @classmethod
+    def get_discriminator_value(cls, obj: Dict[str, Any]) -> Optional[str]:
+        """Returns the discriminator value (object type) of the data"""
+        discriminator_value = obj[cls.__discriminator_property_name]
+        if discriminator_value:
+            return cls.__discriminator_value_class_map.get(discriminator_value)
+        else:
+            return None
+
+{{/discriminator}}
+{{/hasChildren}}
+    def to_str(self) -> str:
+        """Returns the string representation of the model using alias"""
+        return pprint.pformat(self.model_dump(by_alias=True))
+
+    def to_json(self) -> str:
+        """Returns the JSON representation of the model using alias"""
+        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
+        return json.dumps(self.to_dict())
+
+    @classmethod
+    def from_json(cls, json_str: str) -> Optional[{{^hasChildren}}Self{{/hasChildren}}{{#hasChildren}}{{#discriminator}}Union[{{#mappedModels}}{{{modelName}}}{{^-last}}, {{/-last}}{{/mappedModels}}]{{/discriminator}}{{^discriminator}}Self{{/discriminator}}{{/hasChildren}}]:
+        """Create an instance of {{{classname}}} from a JSON string"""
+        return cls.from_dict(json.loads(json_str))
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return the dictionary representation of the model using alias.
+
+        This has the following differences from calling pydantic's
+        `self.model_dump(by_alias=True)`:
+
+        * `None` is only added to the output dict for nullable fields that
+          were set at model initialization. Other fields with value `None`
+          are ignored.
+        {{#vendorExtensions.x-py-readonly}}
+        * OpenAPI `readOnly` fields are excluded.
+        {{/vendorExtensions.x-py-readonly}}
+        {{#isAdditionalPropertiesTrue}}
+        * Fields in `self.additional_properties` are added to the output dict.
+        {{/isAdditionalPropertiesTrue}}
+        """
+        excluded_fields: Set[str] = set([
+            {{#vendorExtensions.x-py-readonly}}
+            "{{{.}}}",
+            {{/vendorExtensions.x-py-readonly}}
+            {{#isAdditionalPropertiesTrue}}
+            "additional_properties",
+            {{/isAdditionalPropertiesTrue}}
+        ])
+
+        _dict = self.model_dump(
+            by_alias=True,
+            exclude=excluded_fields,
+            exclude_none=True,
+        )
+        {{#allVars}}
+        {{#isContainer}}
+        {{#isArray}}
+        {{#items.isArray}}
+        {{^items.items.isPrimitiveType}}
+        # override the default output from pydantic by calling `to_dict()` of each item in {{{name}}} (list of list)
+        _items = []
+        if self.{{{name}}}:
+            for _item_{{{name}}} in self.{{{name}}}:
+                if _item_{{{name}}}:
+                    _items.append(
+                         [_inner_item.to_dict() for _inner_item in _item_{{{name}}} if _inner_item is not None]
+                    )
+            _dict['{{{baseName}}}'] = _items
+        {{/items.items.isPrimitiveType}}
+        {{/items.isArray}}
+        {{^items.isArray}}
+        {{^items.isPrimitiveType}}
+        {{^items.isEnumOrRef}}
+        # override the default output from pydantic by calling `to_dict()` of each item in {{{name}}} (list)
+        _items = []
+        if self.{{{name}}}:
+            for _item_{{{name}}} in self.{{{name}}}:
+                if _item_{{{name}}}:
+                    _items.append(_item_{{{name}}}.to_dict())
+            _dict['{{{baseName}}}'] = _items
+        {{/items.isEnumOrRef}}
+        {{/items.isPrimitiveType}}
+        {{/items.isArray}}
+        {{/isArray}}
+        {{#isMap}}
+        {{#items.isArray}}
+        {{^items.items.isPrimitiveType}}
+        # override the default output from pydantic by calling `to_dict()` of each value in {{{name}}} (dict of array)
+        _field_dict_of_array = {}
+        if self.{{{name}}}:
+            for _key_{{{name}}} in self.{{{name}}}:
+                if self.{{{name}}}[_key_{{{name}}}] is not None:
+                    _field_dict_of_array[_key_{{{name}}}] = [
+                        _item.to_dict() for _item in self.{{{name}}}[_key_{{{name}}}]
+                    ]
+            _dict['{{{baseName}}}'] = _field_dict_of_array
+        {{/items.items.isPrimitiveType}}
+        {{/items.isArray}}
+        {{^items.isArray}}
+        {{^items.isPrimitiveType}}
+        {{^items.isEnumOrRef}}
+        # override the default output from pydantic by calling `to_dict()` of each value in {{{name}}} (dict)
+        _field_dict = {}
+        if self.{{{name}}}:
+            for _key_{{{name}}} in self.{{{name}}}:
+                if self.{{{name}}}[_key_{{{name}}}]:
+                    _field_dict[_key_{{{name}}}] = self.{{{name}}}[_key_{{{name}}}].to_dict()
+            _dict['{{{baseName}}}'] = _field_dict
+        {{/items.isEnumOrRef}}
+        {{/items.isPrimitiveType}}
+        {{/items.isArray}}
+        {{/isMap}}
+        {{/isContainer}}
+        {{^isContainer}}
+        {{^isPrimitiveType}}
+        {{^isEnumOrRef}}
+        # override the default output from pydantic by calling `to_dict()` of {{{name}}}
+        if self.{{{name}}}:
+            _dict['{{{baseName}}}'] = self.{{{name}}}.to_dict()
+        {{/isEnumOrRef}}
+        {{/isPrimitiveType}}
+        {{/isContainer}}
+        {{/allVars}}
+        {{#isAdditionalPropertiesTrue}}
+        # puts key-value pairs in additional_properties in the top level
+        if self.additional_properties is not None:
+            for _key, _value in self.additional_properties.items():
+                _dict[_key] = _value
+
+        {{/isAdditionalPropertiesTrue}}
+        {{#allVars}}
+        {{#isNullable}}
+        # set to None if {{{name}}} (nullable) is None
+        # and model_fields_set contains the field
+        if self.{{name}} is None and "{{{name}}}" in self.model_fields_set:
+            _dict['{{{baseName}}}'] = None
+
+        {{/isNullable}}
+        {{/allVars}}
+        return _dict
+
+    {{#hasChildren}}
+    @classmethod
+    def from_dict(cls, obj: Dict[str, Any]) -> Optional[{{#discriminator}}Union[{{#mappedModels}}{{{modelName}}}{{^-last}}, {{/-last}}{{/mappedModels}}]{{/discriminator}}{{^discriminator}}Self{{/discriminator}}]:
+        """Create an instance of {{{classname}}} from a dict"""
+        {{#discriminator}}
+        # look up the object type based on discriminator mapping
+        object_type = cls.get_discriminator_value(obj)
+        {{#mappedModels}}
+        if object_type ==  '{{{modelName}}}':
+            return import_module("{{packageName}}.models.{{model.classFilename}}").{{modelName}}.from_dict(obj)
+        {{/mappedModels}}
+
+        raise ValueError("{{{classname}}} failed to lookup discriminator value from " +
+                            json.dumps(obj) + ". Discriminator property name: " + cls.__discriminator_property_name +
+                            ", mapping: " + json.dumps(cls.__discriminator_value_class_map))
+        {{/discriminator}}
+    {{/hasChildren}}
+    {{^hasChildren}}
+    @classmethod
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
+        """Create an instance of {{{classname}}} from a dict"""
+        if obj is None:
+            return None
+
+        if not isinstance(obj, dict):
+            return cls.model_validate(obj)
+
+        {{#disallowAdditionalPropertiesIfNotPresent}}
+        {{^isAdditionalPropertiesTrue}}
+        # raise errors for additional fields in the input
+        for _key in obj.keys():
+            if _key not in cls.__properties:
+                raise ValueError("Error due to additional fields (not defined in {{classname}}) in the input: " + _key)
+
+        {{/isAdditionalPropertiesTrue}}
+        {{/disallowAdditionalPropertiesIfNotPresent}}
+        _obj = cls.model_validate({
+            {{#allVars}}
+            {{#isContainer}}
+            {{#isArray}}
+            {{#items.isArray}}
+            {{#items.items.isPrimitiveType}}
+            "{{{baseName}}}": obj.get("{{{baseName}}}"){{^-last}},{{/-last}}
+            {{/items.items.isPrimitiveType}}
+            {{^items.items.isPrimitiveType}}
+            "{{{baseName}}}": [
+                    [{{{items.items.dataType}}}.from_dict(_inner_item) for _inner_item in _item]
+                    for _item in obj["{{{baseName}}}"]
+                ] if obj.get("{{{baseName}}}") is not None else None{{^-last}},{{/-last}}
+            {{/items.items.isPrimitiveType}}
+            {{/items.isArray}}
+            {{^items.isArray}}
+            {{^items.isPrimitiveType}}
+            {{#items.isEnumOrRef}}
+            "{{{baseName}}}": obj.get("{{{baseName}}}"){{^-last}},{{/-last}}
+            {{/items.isEnumOrRef}}
+            {{^items.isEnumOrRef}}
+            "{{{baseName}}}": [{{{items.dataType}}}.from_dict(_item) for _item in obj["{{{baseName}}}"]] if obj.get("{{{baseName}}}") is not None else None{{^-last}},{{/-last}}
+            {{/items.isEnumOrRef}}
+            {{/items.isPrimitiveType}}
+            {{#items.isPrimitiveType}}
+            "{{{baseName}}}": obj.get("{{{baseName}}}"){{^-last}},{{/-last}}
+            {{/items.isPrimitiveType}}
+            {{/items.isArray}}
+            {{/isArray}}
+            {{#isMap}}
+            {{^items.isPrimitiveType}}
+            {{^items.isEnumOrRef}}
+            {{#items.isContainer}}
+            {{#items.isMap}}
+            "{{{baseName}}}": dict(
+                (_k, dict(
+                    (_ik, {{{items.items.dataType}}}.from_dict(_iv))
+                        for _ik, _iv in _v.items()
+                    )
+                    if _v is not None
+                    else None
+                )
+                for _k, _v in obj.get("{{{baseName}}}").items()
+            )
+            if obj.get("{{{baseName}}}") is not None
+            else None{{^-last}},{{/-last}}
+            {{/items.isMap}}
+            {{#items.isArray}}
+            "{{{baseName}}}": dict(
+                (_k,
+                        [{{{items.items.dataType}}}.from_dict(_item) for _item in _v]
+                        if _v is not None
+                        else None
+                )
+                for _k, _v in obj.get("{{{baseName}}}", {}).items()
+            ){{^-last}},{{/-last}}
+            {{/items.isArray}}
+            {{/items.isContainer}}
+            {{^items.isContainer}}
+            "{{{baseName}}}": dict(
+                (_k, {{{items.dataType}}}.from_dict(_v))
+                for _k, _v in obj["{{{baseName}}}"].items()
+            )
+            if obj.get("{{{baseName}}}") is not None
+            else None{{^-last}},{{/-last}}
+            {{/items.isContainer}}
+            {{/items.isEnumOrRef}}
+            {{#items.isEnumOrRef}}
+            "{{{baseName}}}": dict((_k, _v) for _k, _v in obj.get("{{{baseName}}}").items()) if obj.get("{{{baseName}}}") is not None else None{{^-last}},{{/-last}}
+            {{/items.isEnumOrRef}}
+            {{/items.isPrimitiveType}}
+            {{#items.isPrimitiveType}}
+            "{{{baseName}}}": obj.get("{{{baseName}}}"){{^-last}},{{/-last}}
+            {{/items.isPrimitiveType}}
+            {{/isMap}}
+            {{/isContainer}}
+            {{^isContainer}}
+            {{^isPrimitiveType}}
+            {{^isEnumOrRef}}
+            "{{{baseName}}}": {{{dataType}}}.from_dict(obj["{{{baseName}}}"]) if obj.get("{{{baseName}}}") is not None else None{{^-last}},{{/-last}}
+            {{/isEnumOrRef}}
+            {{#isEnumOrRef}}
+            "{{{baseName}}}": obj.get("{{{baseName}}}"){{#defaultValue}} if obj.get("{{baseName}}") is not None else {{defaultValue}}{{/defaultValue}}{{^-last}},{{/-last}}
+            {{/isEnumOrRef}}
+            {{/isPrimitiveType}}
+            {{#isPrimitiveType}}
+            {{#defaultValue}}
+            "{{{baseName}}}": obj.get("{{{baseName}}}") if obj.get("{{{baseName}}}") is not None else {{{defaultValue}}}{{^-last}},{{/-last}}
+            {{/defaultValue}}
+            {{^defaultValue}}
+            "{{{baseName}}}": obj.get("{{{baseName}}}"){{^-last}},{{/-last}}
+            {{/defaultValue}}
+            {{/isPrimitiveType}}
+            {{/isContainer}}
+            {{/allVars}}
+        })
+        {{#isAdditionalPropertiesTrue}}
+        # store additional fields in additional_properties
+        for _key in obj.keys():
+            if _key not in cls.__properties:
+                _obj.additional_properties[_key] = obj.get(_key)
+
+        {{/isAdditionalPropertiesTrue}}
+        return _obj
+    {{/hasChildren}}
+
+{{#vendorExtensions.x-py-postponed-model-imports.size}}
+{{#vendorExtensions.x-py-postponed-model-imports}}
+{{{.}}}
+{{/vendorExtensions.x-py-postponed-model-imports}}
+# TODO: Rewrite to not use raise_errors
+{{classname}}.model_rebuild(raise_errors=False)
+{{/vendorExtensions.x-py-postponed-model-imports.size}}

--- a/test/test_enum_tolerance.py
+++ b/test/test_enum_tolerance.py
@@ -1,0 +1,53 @@
+import json
+import warnings
+
+import pytest
+
+from tremendous.models.list_products_response import ListProductsResponse
+
+
+def build_product(**overrides):
+  product = {
+    "id": "ABCD1234",
+    "name": "Test Product",
+    "description": "A test product",
+    "category": "merchant_card",
+    "disclosure": "",
+    "currency_codes": ["USD"],
+    "countries": [{"abbr": "US"}],
+    "images": [],
+  }
+  product.update(overrides)
+  return product
+
+
+class TestEnumTolerance:
+  """Responses with enum values unknown to this SDK version must not fail parsing.
+
+  See https://github.com/tremendous-rewards/tremendous-python/issues/129
+  """
+
+  def test_known_category_parses_without_warning(self):
+    body = json.dumps({"products": [build_product()]})
+
+    with warnings.catch_warnings():
+      warnings.simplefilter("error")
+      response = ListProductsResponse.from_json(body)
+
+    assert response.products[0].category == "merchant_card"
+
+  def test_unknown_category_parses_with_warning(self):
+    body = json.dumps({"products": [build_product(category="a_category_added_in_the_future")]})
+
+    with pytest.warns(UserWarning, match="Unrecognized value 'a_category_added_in_the_future'"):
+      response = ListProductsResponse.from_json(body)
+
+    assert response.products[0].category == "a_category_added_in_the_future"
+
+  def test_unknown_list_item_parses_with_warning(self):
+    body = json.dumps({"products": [build_product(currency_codes=["USD", "XYZ"])]})
+
+    with pytest.warns(UserWarning, match="Unrecognized value 'XYZ'"):
+      response = ListProductsResponse.from_json(body)
+
+    assert response.products[0].currency_codes == ["USD", "XYZ"]

--- a/tremendous/models/allow_email.py
+++ b/tremendous/models/allow_email.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/allow_email1.py
+++ b/tremendous/models/allow_email1.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/allow_ip.py
+++ b/tremendous/models/allow_ip.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/allow_ip1.py
+++ b/tremendous/models/allow_ip1.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/balance_transaction.py
+++ b/tremendous/models/balance_transaction.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr

--- a/tremendous/models/balance_transaction_order.py
+++ b/tremendous/models/balance_transaction_order.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/balance_transaction_order_payment.py
+++ b/tremendous/models/balance_transaction_order_payment.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional, Union

--- a/tremendous/models/base_order_for_create.py
+++ b/tremendous/models/base_order_for_create.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/campaign.py
+++ b/tremendous/models/campaign.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
@@ -58,7 +59,7 @@ class Campaign(BaseModel):
             return value
 
         if value not in set(['SENDER', 'RECIPIENT']):
-            raise ValueError("must be one of enum values ('SENDER', 'RECIPIENT')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `fee_charged_to`; known values are ('SENDER', 'RECIPIENT'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/campaign_base.py
+++ b/tremendous/models/campaign_base.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
@@ -58,7 +59,7 @@ class CampaignBase(BaseModel):
             return value
 
         if value not in set(['SENDER', 'RECIPIENT']):
-            raise ValueError("must be one of enum values ('SENDER', 'RECIPIENT')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `fee_charged_to`; known values are ('SENDER', 'RECIPIENT'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/connected_organization.py
+++ b/tremendous/models/connected_organization.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator

--- a/tremendous/models/connected_organization_member.py
+++ b/tremendous/models/connected_organization_member.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator

--- a/tremendous/models/connected_organization_member_member.py
+++ b/tremendous/models/connected_organization_member_member.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr, field_validator
@@ -50,7 +51,7 @@ class ConnectedOrganizationMemberMember(BaseModel):
     def status_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['REGISTERED', 'INVITED']):
-            raise ValueError("must be one of enum values ('REGISTERED', 'INVITED')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('REGISTERED', 'INVITED'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/connected_organization_member_session.py
+++ b/tremendous/models/connected_organization_member_session.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator

--- a/tremendous/models/connected_organization_organization.py
+++ b/tremendous/models/connected_organization_organization.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import date
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
@@ -54,7 +55,7 @@ class ConnectedOrganizationOrganization(BaseModel):
             return value
 
         if value not in set(['PENDING', 'APPROVED', 'REJECTED']):
-            raise ValueError("must be one of enum values ('PENDING', 'APPROVED', 'REJECTED')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('PENDING', 'APPROVED', 'REJECTED'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/create_api_key200_response.py
+++ b/tremendous/models/create_api_key200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/create_campaign200_response.py
+++ b/tremendous/models/create_campaign200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/create_campaign_request.py
+++ b/tremendous/models/create_campaign_request.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
@@ -47,7 +48,7 @@ class CreateCampaignRequest(BaseModel):
             return value
 
         if value not in set(['SENDER', 'RECIPIENT']):
-            raise ValueError("must be one of enum values ('SENDER', 'RECIPIENT')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `fee_charged_to`; known values are ('SENDER', 'RECIPIENT'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/create_connected_organization200_response.py
+++ b/tremendous/models/create_connected_organization200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/create_connected_organization_member200_response.py
+++ b/tremendous/models/create_connected_organization_member200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/create_connected_organization_member_request.py
+++ b/tremendous/models/create_connected_organization_member_request.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/create_connected_organization_member_session200_response.py
+++ b/tremendous/models/create_connected_organization_member_session200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/create_connected_organization_member_session200_response_connected_organization_member_session.py
+++ b/tremendous/models/create_connected_organization_member_session200_response_connected_organization_member_session.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator

--- a/tremendous/models/create_connected_organization_member_session_request.py
+++ b/tremendous/models/create_connected_organization_member_session_request.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/create_connected_organization_request.py
+++ b/tremendous/models/create_connected_organization_request.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/create_connected_organization_request_kyb_prefill.py
+++ b/tremendous/models/create_connected_organization_request_kyb_prefill.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/create_field.py
+++ b/tremendous/models/create_field.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
@@ -39,7 +40,7 @@ class CreateField(BaseModel):
     def data_type_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['Checkbox', 'Currency', 'Date', 'Dropdown', 'Email', 'List', 'Number', 'Phone', 'Text', 'TextArea']):
-            raise ValueError("must be one of enum values ('Checkbox', 'Currency', 'Date', 'Dropdown', 'Email', 'List', 'Number', 'Phone', 'Text', 'TextArea')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `data_type`; known values are ('Checkbox', 'Currency', 'Date', 'Dropdown', 'Email', 'List', 'Number', 'Phone', 'Text', 'TextArea'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/create_field200_response.py
+++ b/tremendous/models/create_field200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/create_field_request.py
+++ b/tremendous/models/create_field_request.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
@@ -39,7 +40,7 @@ class CreateFieldRequest(BaseModel):
     def data_type_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['Checkbox', 'Currency', 'Date', 'Dropdown', 'Email', 'List', 'Number', 'Phone', 'Text', 'TextArea']):
-            raise ValueError("must be one of enum values ('Checkbox', 'Currency', 'Date', 'Dropdown', 'Email', 'List', 'Number', 'Phone', 'Text', 'TextArea')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `data_type`; known values are ('Checkbox', 'Currency', 'Date', 'Dropdown', 'Email', 'List', 'Number', 'Phone', 'Text', 'TextArea'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/create_field_request_data.py
+++ b/tremendous/models/create_field_request_data.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/create_invoice200_response.py
+++ b/tremendous/models/create_invoice200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/create_invoice_request.py
+++ b/tremendous/models/create_invoice_request.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional, Union
@@ -41,7 +42,7 @@ class CreateInvoiceRequest(BaseModel):
             return value
 
         if value not in set(['USD', 'EUR', 'GBP']):
-            raise ValueError("must be one of enum values ('USD', 'EUR', 'GBP')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `currency_code`; known values are ('USD', 'EUR', 'GBP'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('currency')
@@ -51,7 +52,7 @@ class CreateInvoiceRequest(BaseModel):
             return value
 
         if value not in set(['USD', 'EUR', 'GBP']):
-            raise ValueError("must be one of enum values ('USD', 'EUR', 'GBP')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `currency`; known values are ('USD', 'EUR', 'GBP'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/create_member.py
+++ b/tremendous/models/create_member.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/create_member200_response.py
+++ b/tremendous/models/create_member200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/create_member_request.py
+++ b/tremendous/models/create_member_request.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/create_order200_response.py
+++ b/tremendous/models/create_order200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/create_order200_response_order.py
+++ b/tremendous/models/create_order200_response_order.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
@@ -63,7 +64,7 @@ class CreateOrder200ResponseOrder(BaseModel):
     def status_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT']):
-            raise ValueError("must be one of enum values ('CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('channel')
@@ -73,7 +74,7 @@ class CreateOrder200ResponseOrder(BaseModel):
             return value
 
         if value not in set(['UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO']):
-            raise ValueError("must be one of enum values ('UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `channel`; known values are ('UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/create_order200_response_order_rewards_inner.py
+++ b/tremendous/models/create_order200_response_order_rewards_inner.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import date, datetime
 from pydantic import BaseModel, ConfigDict, Field, field_validator

--- a/tremendous/models/create_order200_response_order_rewards_inner_delivery.py
+++ b/tremendous/models/create_order200_response_order_rewards_inner_delivery.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
@@ -36,14 +37,14 @@ class CreateOrder200ResponseOrderRewardsInnerDelivery(BaseModel):
     def method_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['EMAIL', 'LINK', 'PHONE']):
-            raise ValueError("must be one of enum values ('EMAIL', 'LINK', 'PHONE')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `method`; known values are ('EMAIL', 'LINK', 'PHONE'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('status')
     def status_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['SCHEDULED', 'FAILED', 'SUCCEEDED', 'PENDING']):
-            raise ValueError("must be one of enum values ('SCHEDULED', 'FAILED', 'SUCCEEDED', 'PENDING')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('SCHEDULED', 'FAILED', 'SUCCEEDED', 'PENDING'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/create_organization.py
+++ b/tremendous/models/create_organization.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import date
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr, field_validator

--- a/tremendous/models/create_organization200_response.py
+++ b/tremendous/models/create_organization200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/create_organization200_response_organization.py
+++ b/tremendous/models/create_organization200_response_organization.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import date
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator

--- a/tremendous/models/create_organization_for_response.py
+++ b/tremendous/models/create_organization_for_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import date
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr, field_validator

--- a/tremendous/models/create_organization_properties.py
+++ b/tremendous/models/create_organization_properties.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import date
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr, field_validator

--- a/tremendous/models/create_organization_request.py
+++ b/tremendous/models/create_organization_request.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/create_organization_request_copy_settings.py
+++ b/tremendous/models/create_organization_request_copy_settings.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictBool
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/create_report200_response.py
+++ b/tremendous/models/create_report200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/create_report200_response_report.py
+++ b/tremendous/models/create_report200_response_report.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
@@ -42,7 +43,7 @@ class CreateReport200ResponseReport(BaseModel):
             return value
 
         if value not in set(['CREATED', 'PROCESSING', 'READY_FOR_DOWNLOAD', 'FAILED']):
-            raise ValueError("must be one of enum values ('CREATED', 'PROCESSING', 'READY_FOR_DOWNLOAD', 'FAILED')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('CREATED', 'PROCESSING', 'READY_FOR_DOWNLOAD', 'FAILED'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/create_report_request.py
+++ b/tremendous/models/create_report_request.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
@@ -37,14 +38,14 @@ class CreateReportRequest(BaseModel):
     def report_type_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['digital_rewards']):
-            raise ValueError("must be one of enum values ('digital_rewards')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `report_type`; known values are ('digital_rewards'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('format')
     def format_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['csv']):
-            raise ValueError("must be one of enum values ('csv')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `format`; known values are ('csv'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/create_report_request_filters.py
+++ b/tremendous/models/create_report_request_filters.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/create_report_request_filters_digital_rewards.py
+++ b/tremendous/models/create_report_request_filters_digital_rewards.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import date
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
@@ -47,7 +48,7 @@ class CreateReportRequestFiltersDigitalRewards(BaseModel):
             return value
 
         if value not in set(['phone', 'email', 'link', 'mail', 'direct']):
-            raise ValueError("must be one of enum values ('phone', 'email', 'link', 'mail', 'direct')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `delivery_method`; known values are ('phone', 'email', 'link', 'mail', 'direct'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('order_status')
@@ -57,7 +58,7 @@ class CreateReportRequestFiltersDigitalRewards(BaseModel):
             return value
 
         if value not in set(['executed', 'canceled', 'failed', 'pending_approval']):
-            raise ValueError("must be one of enum values ('executed', 'canceled', 'failed', 'pending_approval')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `order_status`; known values are ('executed', 'canceled', 'failed', 'pending_approval'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('status')
@@ -68,7 +69,7 @@ class CreateReportRequestFiltersDigitalRewards(BaseModel):
 
         for i in value:
             if i not in set(['delivered', 'canceled', 'delivery_failed', 'pending_review']):
-                raise ValueError("each list item must be one of ('delivered', 'canceled', 'delivery_failed', 'pending_review')")
+                warnings.warn(f"Unrecognized value '{i}' in enum list field `status`; known values are ('delivered', 'canceled', 'delivery_failed', 'pending_review'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/create_report_request_filters_digital_rewards_amount.py
+++ b/tremendous/models/create_report_request_filters_digital_rewards_amount.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt
 from typing import Any, ClassVar, Dict, List, Optional, Union

--- a/tremendous/models/create_report_request_filters_digital_rewards_created_at.py
+++ b/tremendous/models/create_report_request_filters_digital_rewards_created_at.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import date
 from pydantic import BaseModel, ConfigDict, Field

--- a/tremendous/models/create_topup200_response.py
+++ b/tremendous/models/create_topup200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/create_topup_request.py
+++ b/tremendous/models/create_topup_request.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr
 from typing import Any, ClassVar, Dict, List, Union

--- a/tremendous/models/create_webhook200_response.py
+++ b/tremendous/models/create_webhook200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/create_webhook_request.py
+++ b/tremendous/models/create_webhook_request.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/custom_field.py
+++ b/tremendous/models/custom_field.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/delete_fraud_rule200_response.py
+++ b/tremendous/models/delete_fraud_rule200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/delivery_details.py
+++ b/tremendous/models/delivery_details.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
@@ -38,7 +39,7 @@ class DeliveryDetails(BaseModel):
             return value
 
         if value not in set(['EMAIL', 'LINK', 'PHONE']):
-            raise ValueError("must be one of enum values ('EMAIL', 'LINK', 'PHONE')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `method`; known values are ('EMAIL', 'LINK', 'PHONE'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('status')
@@ -48,7 +49,7 @@ class DeliveryDetails(BaseModel):
             return value
 
         if value not in set(['SCHEDULED', 'FAILED', 'SUCCEEDED', 'PENDING']):
-            raise ValueError("must be one of enum values ('SCHEDULED', 'FAILED', 'SUCCEEDED', 'PENDING')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('SCHEDULED', 'FAILED', 'SUCCEEDED', 'PENDING'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/delivery_details_with_link.py
+++ b/tremendous/models/delivery_details_with_link.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
@@ -36,14 +37,14 @@ class DeliveryDetailsWithLink(BaseModel):
     def method_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['EMAIL', 'LINK', 'PHONE']):
-            raise ValueError("must be one of enum values ('EMAIL', 'LINK', 'PHONE')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `method`; known values are ('EMAIL', 'LINK', 'PHONE'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('status')
     def status_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['SCHEDULED', 'FAILED', 'SUCCEEDED', 'PENDING']):
-            raise ValueError("must be one of enum values ('SCHEDULED', 'FAILED', 'SUCCEEDED', 'PENDING')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('SCHEDULED', 'FAILED', 'SUCCEEDED', 'PENDING'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/delivery_metadata.py
+++ b/tremendous/models/delivery_metadata.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/error_model.py
+++ b/tremendous/models/error_model.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictInt
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/fraud_config_allow_email.py
+++ b/tremendous/models/fraud_config_allow_email.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/fraud_config_country.py
+++ b/tremendous/models/fraud_config_country.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List
@@ -35,7 +36,7 @@ class FraudConfigCountry(BaseModel):
     def type_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['whitelist', 'blacklist']):
-            raise ValueError("must be one of enum values ('whitelist', 'blacklist')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `type`; known values are ('whitelist', 'blacklist'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/fraud_config_country_update_list.py
+++ b/tremendous/models/fraud_config_country_update_list.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/fraud_config_ip.py
+++ b/tremendous/models/fraud_config_ip.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/fraud_config_redeemed_rewards_amount.py
+++ b/tremendous/models/fraud_config_redeemed_rewards_amount.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Union
@@ -36,7 +37,7 @@ class FraudConfigRedeemedRewardsAmount(BaseModel):
     def period_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['7', '30', '90', '120', '365', 'all_time']):
-            raise ValueError("must be one of enum values ('7', '30', '90', '120', '365', 'all_time')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `period`; known values are ('7', '30', '90', '120', '365', 'all_time'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/fraud_config_redeemed_rewards_count.py
+++ b/tremendous/models/fraud_config_redeemed_rewards_count.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List
@@ -36,7 +37,7 @@ class FraudConfigRedeemedRewardsCount(BaseModel):
     def period_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['7', '30', '90', '120', '365', 'all_time']):
-            raise ValueError("must be one of enum values ('7', '30', '90', '120', '365', 'all_time')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `period`; known values are ('7', '30', '90', '120', '365', 'all_time'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/fraud_config_review_email.py
+++ b/tremendous/models/fraud_config_review_email.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/fraud_config_review_vpn.py
+++ b/tremendous/models/fraud_config_review_vpn.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictBool
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/fraud_generic_response.py
+++ b/tremendous/models/fraud_generic_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/fraud_review.py
+++ b/tremendous/models/fraud_review.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
@@ -52,7 +53,7 @@ class FraudReview(BaseModel):
             return value
 
         if value not in set(['flagged', 'blocked', 'released']):
-            raise ValueError("must be one of enum values ('flagged', 'blocked', 'released')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('flagged', 'blocked', 'released'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('reasons')
@@ -63,7 +64,7 @@ class FraudReview(BaseModel):
 
         for i in value:
             if i not in set(['Disallowed IP', 'Disallowed email', 'Disallowed country', 'Over reward amount limit', 'Over reward count limit', 'VPN detected', 'Apple Private Relay', 'Device related to multiple emails', 'Device or account related to multiple emails', 'IP on a Tremendous fraud list', 'Bank account on a Tremendous fraud list', 'Fingerprint on a Tremendous fraud list', 'Email on a Tremendous fraud list', 'Phone on a Tremendous fraud list', 'Device on a Tremendous fraud list', 'IP related to a blocked reward', 'Device related to a blocked reward', 'Bank account related to a blocked reward', 'Fingerprint related to a blocked reward', 'Email related to a blocked reward', 'Phone related to a blocked reward', 'Allowed IP', 'Allowed email', 'Allowed country']):
-                raise ValueError("each list item must be one of ('Disallowed IP', 'Disallowed email', 'Disallowed country', 'Over reward amount limit', 'Over reward count limit', 'VPN detected', 'Apple Private Relay', 'Device related to multiple emails', 'Device or account related to multiple emails', 'IP on a Tremendous fraud list', 'Bank account on a Tremendous fraud list', 'Fingerprint on a Tremendous fraud list', 'Email on a Tremendous fraud list', 'Phone on a Tremendous fraud list', 'Device on a Tremendous fraud list', 'IP related to a blocked reward', 'Device related to a blocked reward', 'Bank account related to a blocked reward', 'Fingerprint related to a blocked reward', 'Email related to a blocked reward', 'Phone related to a blocked reward', 'Allowed IP', 'Allowed email', 'Allowed country')")
+                warnings.warn(f"Unrecognized value '{i}' in enum list field `reasons`; known values are ('Disallowed IP', 'Disallowed email', 'Disallowed country', 'Over reward amount limit', 'Over reward count limit', 'VPN detected', 'Apple Private Relay', 'Device related to multiple emails', 'Device or account related to multiple emails', 'IP on a Tremendous fraud list', 'Bank account on a Tremendous fraud list', 'Fingerprint on a Tremendous fraud list', 'Email on a Tremendous fraud list', 'Phone on a Tremendous fraud list', 'Device on a Tremendous fraud list', 'IP related to a blocked reward', 'Device related to a blocked reward', 'Bank account related to a blocked reward', 'Fingerprint related to a blocked reward', 'Email related to a blocked reward', 'Phone related to a blocked reward', 'Allowed IP', 'Allowed email', 'Allowed country'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('redemption_method')
@@ -73,7 +74,7 @@ class FraudReview(BaseModel):
             return value
 
         if value not in set(['bank transfer', 'charity', 'instant debit transfer', 'international bank transfer', 'merchant card', 'paypal', 'venmo', 'visa card']):
-            raise ValueError("must be one of enum values ('bank transfer', 'charity', 'instant debit transfer', 'international bank transfer', 'merchant card', 'paypal', 'venmo', 'visa card')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `redemption_method`; known values are ('bank transfer', 'charity', 'instant debit transfer', 'international bank transfer', 'merchant card', 'paypal', 'venmo', 'visa card'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('risk')
@@ -83,7 +84,7 @@ class FraudReview(BaseModel):
             return value
 
         if value not in set(['high', 'medium', 'low']):
-            raise ValueError("must be one of enum values ('high', 'medium', 'low')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `risk`; known values are ('high', 'medium', 'low'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/fraud_review_base.py
+++ b/tremendous/models/fraud_review_base.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
@@ -49,7 +50,7 @@ class FraudReviewBase(BaseModel):
             return value
 
         if value not in set(['flagged', 'blocked', 'released']):
-            raise ValueError("must be one of enum values ('flagged', 'blocked', 'released')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('flagged', 'blocked', 'released'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('reasons')
@@ -60,7 +61,7 @@ class FraudReviewBase(BaseModel):
 
         for i in value:
             if i not in set(['Disallowed IP', 'Disallowed email', 'Disallowed country', 'Over reward amount limit', 'Over reward count limit', 'VPN detected', 'Apple Private Relay', 'Device related to multiple emails', 'Device or account related to multiple emails', 'IP on a Tremendous fraud list', 'Bank account on a Tremendous fraud list', 'Fingerprint on a Tremendous fraud list', 'Email on a Tremendous fraud list', 'Phone on a Tremendous fraud list', 'Device on a Tremendous fraud list', 'IP related to a blocked reward', 'Device related to a blocked reward', 'Bank account related to a blocked reward', 'Fingerprint related to a blocked reward', 'Email related to a blocked reward', 'Phone related to a blocked reward', 'Allowed IP', 'Allowed email', 'Allowed country']):
-                raise ValueError("each list item must be one of ('Disallowed IP', 'Disallowed email', 'Disallowed country', 'Over reward amount limit', 'Over reward count limit', 'VPN detected', 'Apple Private Relay', 'Device related to multiple emails', 'Device or account related to multiple emails', 'IP on a Tremendous fraud list', 'Bank account on a Tremendous fraud list', 'Fingerprint on a Tremendous fraud list', 'Email on a Tremendous fraud list', 'Phone on a Tremendous fraud list', 'Device on a Tremendous fraud list', 'IP related to a blocked reward', 'Device related to a blocked reward', 'Bank account related to a blocked reward', 'Fingerprint related to a blocked reward', 'Email related to a blocked reward', 'Phone related to a blocked reward', 'Allowed IP', 'Allowed email', 'Allowed country')")
+                warnings.warn(f"Unrecognized value '{i}' in enum list field `reasons`; known values are ('Disallowed IP', 'Disallowed email', 'Disallowed country', 'Over reward amount limit', 'Over reward count limit', 'VPN detected', 'Apple Private Relay', 'Device related to multiple emails', 'Device or account related to multiple emails', 'IP on a Tremendous fraud list', 'Bank account on a Tremendous fraud list', 'Fingerprint on a Tremendous fraud list', 'Email on a Tremendous fraud list', 'Phone on a Tremendous fraud list', 'Device on a Tremendous fraud list', 'IP related to a blocked reward', 'Device related to a blocked reward', 'Bank account related to a blocked reward', 'Fingerprint related to a blocked reward', 'Email related to a blocked reward', 'Phone related to a blocked reward', 'Allowed IP', 'Allowed email', 'Allowed country'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('redemption_method')
@@ -70,7 +71,7 @@ class FraudReviewBase(BaseModel):
             return value
 
         if value not in set(['bank transfer', 'charity', 'instant debit transfer', 'international bank transfer', 'merchant card', 'paypal', 'venmo', 'visa card']):
-            raise ValueError("must be one of enum values ('bank transfer', 'charity', 'instant debit transfer', 'international bank transfer', 'merchant card', 'paypal', 'venmo', 'visa card')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `redemption_method`; known values are ('bank transfer', 'charity', 'instant debit transfer', 'international bank transfer', 'merchant card', 'paypal', 'venmo', 'visa card'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/fraud_review_geo.py
+++ b/tremendous/models/fraud_review_geo.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/fraud_review_list_item.py
+++ b/tremendous/models/fraud_review_list_item.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
@@ -49,7 +50,7 @@ class FraudReviewListItem(BaseModel):
             return value
 
         if value not in set(['flagged', 'blocked', 'released']):
-            raise ValueError("must be one of enum values ('flagged', 'blocked', 'released')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('flagged', 'blocked', 'released'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('reasons')
@@ -60,7 +61,7 @@ class FraudReviewListItem(BaseModel):
 
         for i in value:
             if i not in set(['Disallowed IP', 'Disallowed email', 'Disallowed country', 'Over reward amount limit', 'Over reward count limit', 'VPN detected', 'Apple Private Relay', 'Device related to multiple emails', 'Device or account related to multiple emails', 'IP on a Tremendous fraud list', 'Bank account on a Tremendous fraud list', 'Fingerprint on a Tremendous fraud list', 'Email on a Tremendous fraud list', 'Phone on a Tremendous fraud list', 'Device on a Tremendous fraud list', 'IP related to a blocked reward', 'Device related to a blocked reward', 'Bank account related to a blocked reward', 'Fingerprint related to a blocked reward', 'Email related to a blocked reward', 'Phone related to a blocked reward', 'Allowed IP', 'Allowed email', 'Allowed country']):
-                raise ValueError("each list item must be one of ('Disallowed IP', 'Disallowed email', 'Disallowed country', 'Over reward amount limit', 'Over reward count limit', 'VPN detected', 'Apple Private Relay', 'Device related to multiple emails', 'Device or account related to multiple emails', 'IP on a Tremendous fraud list', 'Bank account on a Tremendous fraud list', 'Fingerprint on a Tremendous fraud list', 'Email on a Tremendous fraud list', 'Phone on a Tremendous fraud list', 'Device on a Tremendous fraud list', 'IP related to a blocked reward', 'Device related to a blocked reward', 'Bank account related to a blocked reward', 'Fingerprint related to a blocked reward', 'Email related to a blocked reward', 'Phone related to a blocked reward', 'Allowed IP', 'Allowed email', 'Allowed country')")
+                warnings.warn(f"Unrecognized value '{i}' in enum list field `reasons`; known values are ('Disallowed IP', 'Disallowed email', 'Disallowed country', 'Over reward amount limit', 'Over reward count limit', 'VPN detected', 'Apple Private Relay', 'Device related to multiple emails', 'Device or account related to multiple emails', 'IP on a Tremendous fraud list', 'Bank account on a Tremendous fraud list', 'Fingerprint on a Tremendous fraud list', 'Email on a Tremendous fraud list', 'Phone on a Tremendous fraud list', 'Device on a Tremendous fraud list', 'IP related to a blocked reward', 'Device related to a blocked reward', 'Bank account related to a blocked reward', 'Fingerprint related to a blocked reward', 'Email related to a blocked reward', 'Phone related to a blocked reward', 'Allowed IP', 'Allowed email', 'Allowed country'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('redemption_method')
@@ -70,7 +71,7 @@ class FraudReviewListItem(BaseModel):
             return value
 
         if value not in set(['bank transfer', 'charity', 'instant debit transfer', 'international bank transfer', 'merchant card', 'paypal', 'venmo', 'visa card']):
-            raise ValueError("must be one of enum values ('bank transfer', 'charity', 'instant debit transfer', 'international bank transfer', 'merchant card', 'paypal', 'venmo', 'visa card')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `redemption_method`; known values are ('bank transfer', 'charity', 'instant debit transfer', 'international bank transfer', 'merchant card', 'paypal', 'venmo', 'visa card'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/fraud_review_related_rewards.py
+++ b/tremendous/models/fraud_review_related_rewards.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional, Union

--- a/tremendous/models/fraud_rule200_response.py
+++ b/tremendous/models/fraud_rule200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/fraud_rule400_response.py
+++ b/tremendous/models/fraud_rule400_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictInt
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/fraud_rule422_response.py
+++ b/tremendous/models/fraud_rule422_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictInt
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/fraud_rule_request.py
+++ b/tremendous/models/fraud_rule_request.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/fraud_rules_list_item.py
+++ b/tremendous/models/fraud_rules_list_item.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
@@ -38,7 +39,7 @@ class FraudRulesListItem(BaseModel):
             return value
 
         if value not in set(['review_country', 'review_ip', 'review_email', 'review_redeemed_rewards_count', 'review_redeemed_rewards_amount', 'review_multiple_emails', 'review_vpn', 'review_tremendous_flag_list', 'review_previously_blocked_recipients', 'allow_ip', 'allow_email']):
-            raise ValueError("must be one of enum values ('review_country', 'review_ip', 'review_email', 'review_redeemed_rewards_count', 'review_redeemed_rewards_amount', 'review_multiple_emails', 'review_vpn', 'review_tremendous_flag_list', 'review_previously_blocked_recipients', 'allow_ip', 'allow_email')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `rule_type`; known values are ('review_country', 'review_ip', 'review_email', 'review_redeemed_rewards_count', 'review_redeemed_rewards_amount', 'review_multiple_emails', 'review_vpn', 'review_tremendous_flag_list', 'review_previously_blocked_recipients', 'allow_ip', 'allow_email'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/funding_source.py
+++ b/tremendous/models/funding_source.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
@@ -48,7 +49,7 @@ class FundingSource(BaseModel):
     def method_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['balance', 'bank_account', 'credit_card', 'invoice']):
-            raise ValueError("must be one of enum values ('balance', 'bank_account', 'credit_card', 'invoice')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `method`; known values are ('balance', 'bank_account', 'credit_card', 'invoice'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('usage_permissions')
@@ -59,7 +60,7 @@ class FundingSource(BaseModel):
 
         for i in value:
             if i not in set(['api_orders', 'dashboard_orders', 'balance_funding']):
-                raise ValueError("each list item must be one of ('api_orders', 'dashboard_orders', 'balance_funding')")
+                warnings.warn(f"Unrecognized value '{i}' in enum list field `usage_permissions`; known values are ('api_orders', 'dashboard_orders', 'balance_funding'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('status')
@@ -69,7 +70,7 @@ class FundingSource(BaseModel):
             return value
 
         if value not in set(['active', 'deleted', 'failed']):
-            raise ValueError("must be one of enum values ('active', 'deleted', 'failed')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('active', 'deleted', 'failed'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('type')
@@ -79,7 +80,7 @@ class FundingSource(BaseModel):
             return value
 
         if value not in set(['COMMERCIAL', 'PRO_FORMA', 'PREFUNDING_ONLY']):
-            raise ValueError("must be one of enum values ('COMMERCIAL', 'PRO_FORMA', 'PREFUNDING_ONLY')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `type`; known values are ('COMMERCIAL', 'PRO_FORMA', 'PREFUNDING_ONLY'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/generate_reward_link200_response.py
+++ b/tremendous/models/generate_reward_link200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/generate_reward_link200_response_reward.py
+++ b/tremendous/models/generate_reward_link200_response_reward.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/generate_reward_link403_response.py
+++ b/tremendous/models/generate_reward_link403_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictInt
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/get_fraud_review200_response.py
+++ b/tremendous/models/get_fraud_review200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/get_fraud_review200_response_fraud_review.py
+++ b/tremendous/models/get_fraud_review200_response_fraud_review.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
@@ -52,7 +53,7 @@ class GetFraudReview200ResponseFraudReview(BaseModel):
             return value
 
         if value not in set(['flagged', 'blocked', 'released']):
-            raise ValueError("must be one of enum values ('flagged', 'blocked', 'released')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('flagged', 'blocked', 'released'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('reasons')
@@ -63,7 +64,7 @@ class GetFraudReview200ResponseFraudReview(BaseModel):
 
         for i in value:
             if i not in set(['Disallowed IP', 'Disallowed email', 'Disallowed country', 'Over reward amount limit', 'Over reward count limit', 'VPN detected', 'Apple Private Relay', 'Device related to multiple emails', 'Device or account related to multiple emails', 'IP on a Tremendous fraud list', 'Bank account on a Tremendous fraud list', 'Fingerprint on a Tremendous fraud list', 'Email on a Tremendous fraud list', 'Phone on a Tremendous fraud list', 'Device on a Tremendous fraud list', 'IP related to a blocked reward', 'Device related to a blocked reward', 'Bank account related to a blocked reward', 'Fingerprint related to a blocked reward', 'Email related to a blocked reward', 'Phone related to a blocked reward', 'Allowed IP', 'Allowed email', 'Allowed country']):
-                raise ValueError("each list item must be one of ('Disallowed IP', 'Disallowed email', 'Disallowed country', 'Over reward amount limit', 'Over reward count limit', 'VPN detected', 'Apple Private Relay', 'Device related to multiple emails', 'Device or account related to multiple emails', 'IP on a Tremendous fraud list', 'Bank account on a Tremendous fraud list', 'Fingerprint on a Tremendous fraud list', 'Email on a Tremendous fraud list', 'Phone on a Tremendous fraud list', 'Device on a Tremendous fraud list', 'IP related to a blocked reward', 'Device related to a blocked reward', 'Bank account related to a blocked reward', 'Fingerprint related to a blocked reward', 'Email related to a blocked reward', 'Phone related to a blocked reward', 'Allowed IP', 'Allowed email', 'Allowed country')")
+                warnings.warn(f"Unrecognized value '{i}' in enum list field `reasons`; known values are ('Disallowed IP', 'Disallowed email', 'Disallowed country', 'Over reward amount limit', 'Over reward count limit', 'VPN detected', 'Apple Private Relay', 'Device related to multiple emails', 'Device or account related to multiple emails', 'IP on a Tremendous fraud list', 'Bank account on a Tremendous fraud list', 'Fingerprint on a Tremendous fraud list', 'Email on a Tremendous fraud list', 'Phone on a Tremendous fraud list', 'Device on a Tremendous fraud list', 'IP related to a blocked reward', 'Device related to a blocked reward', 'Bank account related to a blocked reward', 'Fingerprint related to a blocked reward', 'Email related to a blocked reward', 'Phone related to a blocked reward', 'Allowed IP', 'Allowed email', 'Allowed country'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('redemption_method')
@@ -73,7 +74,7 @@ class GetFraudReview200ResponseFraudReview(BaseModel):
             return value
 
         if value not in set(['bank transfer', 'charity', 'instant debit transfer', 'international bank transfer', 'merchant card', 'paypal', 'venmo', 'visa card']):
-            raise ValueError("must be one of enum values ('bank transfer', 'charity', 'instant debit transfer', 'international bank transfer', 'merchant card', 'paypal', 'venmo', 'visa card')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `redemption_method`; known values are ('bank transfer', 'charity', 'instant debit transfer', 'international bank transfer', 'merchant card', 'paypal', 'venmo', 'visa card'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('risk')
@@ -83,7 +84,7 @@ class GetFraudReview200ResponseFraudReview(BaseModel):
             return value
 
         if value not in set(['high', 'medium', 'low']):
-            raise ValueError("must be one of enum values ('high', 'medium', 'low')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `risk`; known values are ('high', 'medium', 'low'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/get_fraud_review200_response_fraud_review_related_rewards.py
+++ b/tremendous/models/get_fraud_review200_response_fraud_review_related_rewards.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional, Union

--- a/tremendous/models/get_funding_source200_response.py
+++ b/tremendous/models/get_funding_source200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/get_member200_response.py
+++ b/tremendous/models/get_member200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/get_member200_response_member.py
+++ b/tremendous/models/get_member200_response_member.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
@@ -49,7 +50,7 @@ class GetMember200ResponseMember(BaseModel):
     def status_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['REGISTERED', 'INVITED']):
-            raise ValueError("must be one of enum values ('REGISTERED', 'INVITED')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('REGISTERED', 'INVITED'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/get_member200_response_member_events_inner.py
+++ b/tremendous/models/get_member200_response_member_events_inner.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
@@ -39,7 +40,7 @@ class GetMember200ResponseMemberEventsInner(BaseModel):
             return value
 
         if value not in set(['created', 'last_login']):
-            raise ValueError("must be one of enum values ('created', 'last_login')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `type`; known values are ('created', 'last_login'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/get_order200_response.py
+++ b/tremendous/models/get_order200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/get_organization200_response.py
+++ b/tremendous/models/get_organization200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/get_product_response.py
+++ b/tremendous/models/get_product_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/get_reward200_response.py
+++ b/tremendous/models/get_reward200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/inline_object.py
+++ b/tremendous/models/inline_object.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictInt, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/inline_object1.py
+++ b/tremendous/models/inline_object1.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/inline_object1_reward.py
+++ b/tremendous/models/inline_object1_reward.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator

--- a/tremendous/models/invoice.py
+++ b/tremendous/models/invoice.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictFloat, StrictInt, StrictStr, field_validator
@@ -49,7 +50,7 @@ class Invoice(BaseModel):
             return value
 
         if value not in set(['USD', 'EUR', 'GBP']):
-            raise ValueError("must be one of enum values ('USD', 'EUR', 'GBP')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `currency_code`; known values are ('USD', 'EUR', 'GBP'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('currency')
@@ -59,14 +60,14 @@ class Invoice(BaseModel):
             return value
 
         if value not in set(['USD', 'EUR', 'GBP']):
-            raise ValueError("must be one of enum values ('USD', 'EUR', 'GBP')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `currency`; known values are ('USD', 'EUR', 'GBP'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('status')
     def status_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['DELETED', 'PAID', 'OPEN', 'MARKED_AS_PAID']):
-            raise ValueError("must be one of enum values ('DELETED', 'PAID', 'OPEN', 'MARKED_AS_PAID')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('DELETED', 'PAID', 'OPEN', 'MARKED_AS_PAID'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/list_balance_transactions200_response.py
+++ b/tremendous/models/list_balance_transactions200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/list_balance_transactions200_response_transactions_inner.py
+++ b/tremendous/models/list_balance_transactions200_response_transactions_inner.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr

--- a/tremendous/models/list_balance_transactions200_response_transactions_inner_order.py
+++ b/tremendous/models/list_balance_transactions200_response_transactions_inner_order.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/list_balance_transactions200_response_transactions_inner_order_payment.py
+++ b/tremendous/models/list_balance_transactions200_response_transactions_inner_order_payment.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional, Union

--- a/tremendous/models/list_campaigns200_response.py
+++ b/tremendous/models/list_campaigns200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/list_campaigns200_response_campaigns_inner.py
+++ b/tremendous/models/list_campaigns200_response_campaigns_inner.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
@@ -58,7 +59,7 @@ class ListCampaigns200ResponseCampaignsInner(BaseModel):
             return value
 
         if value not in set(['SENDER', 'RECIPIENT']):
-            raise ValueError("must be one of enum values ('SENDER', 'RECIPIENT')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `fee_charged_to`; known values are ('SENDER', 'RECIPIENT'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/list_campaigns200_response_campaigns_inner_auto_add_product_rule.py
+++ b/tremendous/models/list_campaigns200_response_campaigns_inner_auto_add_product_rule.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/list_campaigns200_response_campaigns_inner_email_style.py
+++ b/tremendous/models/list_campaigns200_response_campaigns_inner_email_style.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictInt, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/list_campaigns200_response_campaigns_inner_webpage_style.py
+++ b/tremendous/models/list_campaigns200_response_campaigns_inner_webpage_style.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictInt, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/list_connected_organization_members200_response.py
+++ b/tremendous/models/list_connected_organization_members200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictInt
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/list_connected_organization_members200_response_connected_organization_members_inner.py
+++ b/tremendous/models/list_connected_organization_members200_response_connected_organization_members_inner.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator

--- a/tremendous/models/list_connected_organization_members200_response_connected_organization_members_inner_member.py
+++ b/tremendous/models/list_connected_organization_members200_response_connected_organization_members_inner_member.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr, field_validator
@@ -50,7 +51,7 @@ class ListConnectedOrganizationMembers200ResponseConnectedOrganizationMembersInn
     def status_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['REGISTERED', 'INVITED']):
-            raise ValueError("must be one of enum values ('REGISTERED', 'INVITED')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('REGISTERED', 'INVITED'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/list_connected_organizations200_response.py
+++ b/tremendous/models/list_connected_organizations200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictInt
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/list_connected_organizations200_response_connected_organizations_inner.py
+++ b/tremendous/models/list_connected_organizations200_response_connected_organizations_inner.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator

--- a/tremendous/models/list_connected_organizations200_response_connected_organizations_inner_organization.py
+++ b/tremendous/models/list_connected_organizations200_response_connected_organizations_inner_organization.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import date
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
@@ -54,7 +55,7 @@ class ListConnectedOrganizations200ResponseConnectedOrganizationsInnerOrganizati
             return value
 
         if value not in set(['PENDING', 'APPROVED', 'REJECTED']):
-            raise ValueError("must be one of enum values ('PENDING', 'APPROVED', 'REJECTED')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('PENDING', 'APPROVED', 'REJECTED'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/list_fields200_response.py
+++ b/tremendous/models/list_fields200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/list_fields200_response_fields_inner.py
+++ b/tremendous/models/list_fields200_response_fields_inner.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
@@ -54,7 +55,7 @@ class ListFields200ResponseFieldsInner(BaseModel):
             return value
 
         if value not in set(['Checkbox', 'Currency', 'Date', 'Dropdown', 'Email', 'List', 'Number', 'Phone', 'Text', 'TextArea']):
-            raise ValueError("must be one of enum values ('Checkbox', 'Currency', 'Date', 'Dropdown', 'Email', 'List', 'Number', 'Phone', 'Text', 'TextArea')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `data_type`; known values are ('Checkbox', 'Currency', 'Date', 'Dropdown', 'Email', 'List', 'Number', 'Phone', 'Text', 'TextArea'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/list_fields200_response_fields_inner_data.py
+++ b/tremendous/models/list_fields200_response_fields_inner_data.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/list_forex_response.py
+++ b/tremendous/models/list_forex_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, StrictFloat, StrictInt
 from typing import Any, ClassVar, Dict, List, Union

--- a/tremendous/models/list_fraud_reviews200_response.py
+++ b/tremendous/models/list_fraud_reviews200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictInt
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/list_fraud_reviews200_response_fraud_reviews_inner.py
+++ b/tremendous/models/list_fraud_reviews200_response_fraud_reviews_inner.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
@@ -49,7 +50,7 @@ class ListFraudReviews200ResponseFraudReviewsInner(BaseModel):
             return value
 
         if value not in set(['flagged', 'blocked', 'released']):
-            raise ValueError("must be one of enum values ('flagged', 'blocked', 'released')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('flagged', 'blocked', 'released'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('reasons')
@@ -60,7 +61,7 @@ class ListFraudReviews200ResponseFraudReviewsInner(BaseModel):
 
         for i in value:
             if i not in set(['Disallowed IP', 'Disallowed email', 'Disallowed country', 'Over reward amount limit', 'Over reward count limit', 'VPN detected', 'Apple Private Relay', 'Device related to multiple emails', 'Device or account related to multiple emails', 'IP on a Tremendous fraud list', 'Bank account on a Tremendous fraud list', 'Fingerprint on a Tremendous fraud list', 'Email on a Tremendous fraud list', 'Phone on a Tremendous fraud list', 'Device on a Tremendous fraud list', 'IP related to a blocked reward', 'Device related to a blocked reward', 'Bank account related to a blocked reward', 'Fingerprint related to a blocked reward', 'Email related to a blocked reward', 'Phone related to a blocked reward', 'Allowed IP', 'Allowed email', 'Allowed country']):
-                raise ValueError("each list item must be one of ('Disallowed IP', 'Disallowed email', 'Disallowed country', 'Over reward amount limit', 'Over reward count limit', 'VPN detected', 'Apple Private Relay', 'Device related to multiple emails', 'Device or account related to multiple emails', 'IP on a Tremendous fraud list', 'Bank account on a Tremendous fraud list', 'Fingerprint on a Tremendous fraud list', 'Email on a Tremendous fraud list', 'Phone on a Tremendous fraud list', 'Device on a Tremendous fraud list', 'IP related to a blocked reward', 'Device related to a blocked reward', 'Bank account related to a blocked reward', 'Fingerprint related to a blocked reward', 'Email related to a blocked reward', 'Phone related to a blocked reward', 'Allowed IP', 'Allowed email', 'Allowed country')")
+                warnings.warn(f"Unrecognized value '{i}' in enum list field `reasons`; known values are ('Disallowed IP', 'Disallowed email', 'Disallowed country', 'Over reward amount limit', 'Over reward count limit', 'VPN detected', 'Apple Private Relay', 'Device related to multiple emails', 'Device or account related to multiple emails', 'IP on a Tremendous fraud list', 'Bank account on a Tremendous fraud list', 'Fingerprint on a Tremendous fraud list', 'Email on a Tremendous fraud list', 'Phone on a Tremendous fraud list', 'Device on a Tremendous fraud list', 'IP related to a blocked reward', 'Device related to a blocked reward', 'Bank account related to a blocked reward', 'Fingerprint related to a blocked reward', 'Email related to a blocked reward', 'Phone related to a blocked reward', 'Allowed IP', 'Allowed email', 'Allowed country'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('redemption_method')
@@ -70,7 +71,7 @@ class ListFraudReviews200ResponseFraudReviewsInner(BaseModel):
             return value
 
         if value not in set(['bank transfer', 'charity', 'instant debit transfer', 'international bank transfer', 'merchant card', 'paypal', 'venmo', 'visa card']):
-            raise ValueError("must be one of enum values ('bank transfer', 'charity', 'instant debit transfer', 'international bank transfer', 'merchant card', 'paypal', 'venmo', 'visa card')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `redemption_method`; known values are ('bank transfer', 'charity', 'instant debit transfer', 'international bank transfer', 'merchant card', 'paypal', 'venmo', 'visa card'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/list_fraud_reviews200_response_fraud_reviews_inner_geo.py
+++ b/tremendous/models/list_fraud_reviews200_response_fraud_reviews_inner_geo.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/list_fraud_rules200_response.py
+++ b/tremendous/models/list_fraud_rules200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/list_fraud_rules200_response_fraud_rules_inner.py
+++ b/tremendous/models/list_fraud_rules200_response_fraud_rules_inner.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
@@ -38,7 +39,7 @@ class ListFraudRules200ResponseFraudRulesInner(BaseModel):
             return value
 
         if value not in set(['review_country', 'review_ip', 'review_email', 'review_redeemed_rewards_count', 'review_redeemed_rewards_amount', 'review_multiple_emails', 'review_vpn', 'review_tremendous_flag_list', 'review_previously_blocked_recipients', 'allow_ip', 'allow_email']):
-            raise ValueError("must be one of enum values ('review_country', 'review_ip', 'review_email', 'review_redeemed_rewards_count', 'review_redeemed_rewards_amount', 'review_multiple_emails', 'review_vpn', 'review_tremendous_flag_list', 'review_previously_blocked_recipients', 'allow_ip', 'allow_email')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `rule_type`; known values are ('review_country', 'review_ip', 'review_email', 'review_redeemed_rewards_count', 'review_redeemed_rewards_amount', 'review_multiple_emails', 'review_vpn', 'review_tremendous_flag_list', 'review_previously_blocked_recipients', 'allow_ip', 'allow_email'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/list_funding_sources200_response.py
+++ b/tremendous/models/list_funding_sources200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/list_funding_sources200_response_funding_sources_inner.py
+++ b/tremendous/models/list_funding_sources200_response_funding_sources_inner.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
@@ -48,7 +49,7 @@ class ListFundingSources200ResponseFundingSourcesInner(BaseModel):
     def method_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['balance', 'bank_account', 'credit_card', 'invoice']):
-            raise ValueError("must be one of enum values ('balance', 'bank_account', 'credit_card', 'invoice')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `method`; known values are ('balance', 'bank_account', 'credit_card', 'invoice'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('usage_permissions')
@@ -59,7 +60,7 @@ class ListFundingSources200ResponseFundingSourcesInner(BaseModel):
 
         for i in value:
             if i not in set(['api_orders', 'dashboard_orders', 'balance_funding']):
-                raise ValueError("each list item must be one of ('api_orders', 'dashboard_orders', 'balance_funding')")
+                warnings.warn(f"Unrecognized value '{i}' in enum list field `usage_permissions`; known values are ('api_orders', 'dashboard_orders', 'balance_funding'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('status')
@@ -69,7 +70,7 @@ class ListFundingSources200ResponseFundingSourcesInner(BaseModel):
             return value
 
         if value not in set(['active', 'deleted', 'failed']):
-            raise ValueError("must be one of enum values ('active', 'deleted', 'failed')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('active', 'deleted', 'failed'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('type')
@@ -79,7 +80,7 @@ class ListFundingSources200ResponseFundingSourcesInner(BaseModel):
             return value
 
         if value not in set(['COMMERCIAL', 'PRO_FORMA', 'PREFUNDING_ONLY']):
-            raise ValueError("must be one of enum values ('COMMERCIAL', 'PRO_FORMA', 'PREFUNDING_ONLY')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `type`; known values are ('COMMERCIAL', 'PRO_FORMA', 'PREFUNDING_ONLY'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/list_funding_sources200_response_funding_sources_inner_meta.py
+++ b/tremendous/models/list_funding_sources200_response_funding_sources_inner_meta.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictFloat, StrictInt, StrictStr, field_validator
@@ -71,7 +72,7 @@ class ListFundingSources200ResponseFundingSourcesInnerMeta(BaseModel):
             return value
 
         if value not in set(['checking', 'savings']):
-            raise ValueError("must be one of enum values ('checking', 'savings')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `account_type`; known values are ('checking', 'savings'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('account_number_mask')
@@ -101,7 +102,7 @@ class ListFundingSources200ResponseFundingSourcesInnerMeta(BaseModel):
             return value
 
         if value not in set(['MasterCard', 'Amex', 'JCB', 'Diner\'s Club', 'Visa', 'Discover', 'Laser', 'Elo', 'Maestro', 'Solo']):
-            raise ValueError("must be one of enum values ('MasterCard', 'Amex', 'JCB', 'Diner\'s Club', 'Visa', 'Discover', 'Laser', 'Elo', 'Maestro', 'Solo')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `network`; known values are ('MasterCard', 'Amex', 'JCB', 'Diner\'s Club', 'Visa', 'Discover', 'Laser', 'Elo', 'Maestro', 'Solo'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('last4')

--- a/tremendous/models/list_funding_sources200_response_funding_sources_inner_meta_failure_details.py
+++ b/tremendous/models/list_funding_sources200_response_funding_sources_inner_meta_failure_details.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/list_invoices200_response.py
+++ b/tremendous/models/list_invoices200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictInt
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/list_invoices200_response_invoices_inner.py
+++ b/tremendous/models/list_invoices200_response_invoices_inner.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictFloat, StrictInt, StrictStr, field_validator
@@ -49,7 +50,7 @@ class ListInvoices200ResponseInvoicesInner(BaseModel):
             return value
 
         if value not in set(['USD', 'EUR', 'GBP']):
-            raise ValueError("must be one of enum values ('USD', 'EUR', 'GBP')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `currency_code`; known values are ('USD', 'EUR', 'GBP'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('currency')
@@ -59,14 +60,14 @@ class ListInvoices200ResponseInvoicesInner(BaseModel):
             return value
 
         if value not in set(['USD', 'EUR', 'GBP']):
-            raise ValueError("must be one of enum values ('USD', 'EUR', 'GBP')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `currency`; known values are ('USD', 'EUR', 'GBP'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('status')
     def status_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['DELETED', 'PAID', 'OPEN', 'MARKED_AS_PAID']):
-            raise ValueError("must be one of enum values ('DELETED', 'PAID', 'OPEN', 'MARKED_AS_PAID')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('DELETED', 'PAID', 'OPEN', 'MARKED_AS_PAID'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/list_members200_response.py
+++ b/tremendous/models/list_members200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/list_members200_response_members_inner.py
+++ b/tremendous/models/list_members200_response_members_inner.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr, field_validator
@@ -50,7 +51,7 @@ class ListMembers200ResponseMembersInner(BaseModel):
     def status_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['REGISTERED', 'INVITED']):
-            raise ValueError("must be one of enum values ('REGISTERED', 'INVITED')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('REGISTERED', 'INVITED'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/list_orders200_response.py
+++ b/tremendous/models/list_orders200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictInt
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/list_orders200_response_orders_inner.py
+++ b/tremendous/models/list_orders200_response_orders_inner.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
@@ -63,7 +64,7 @@ class ListOrders200ResponseOrdersInner(BaseModel):
     def status_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT']):
-            raise ValueError("must be one of enum values ('CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('channel')
@@ -73,7 +74,7 @@ class ListOrders200ResponseOrdersInner(BaseModel):
             return value
 
         if value not in set(['UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO']):
-            raise ValueError("must be one of enum values ('UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `channel`; known values are ('UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/list_orders200_response_orders_inner_payment.py
+++ b/tremendous/models/list_orders200_response_orders_inner_payment.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional, Union

--- a/tremendous/models/list_orders200_response_orders_inner_payment_refund.py
+++ b/tremendous/models/list_orders200_response_orders_inner_payment_refund.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Union

--- a/tremendous/models/list_organizations200_response.py
+++ b/tremendous/models/list_organizations200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/list_organizations200_response_organizations_inner.py
+++ b/tremendous/models/list_organizations200_response_organizations_inner.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import date
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
@@ -54,7 +55,7 @@ class ListOrganizations200ResponseOrganizationsInner(BaseModel):
             return value
 
         if value not in set(['PENDING', 'APPROVED', 'REJECTED']):
-            raise ValueError("must be one of enum values ('PENDING', 'APPROVED', 'REJECTED')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('PENDING', 'APPROVED', 'REJECTED'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/list_products_response.py
+++ b/tremendous/models/list_products_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/list_products_response_products_inner.py
+++ b/tremendous/models/list_products_response_products_inner.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
@@ -57,7 +58,7 @@ class ListProductsResponseProductsInner(BaseModel):
     def category_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['ach', 'charity', 'instant_debit_transfer', 'merchant_card', 'paypal', 'venmo', 'visa_card', 'cash_app', 'international_bank', 'wallet']):
-            raise ValueError("must be one of enum values ('ach', 'charity', 'instant_debit_transfer', 'merchant_card', 'paypal', 'venmo', 'visa_card', 'cash_app', 'international_bank', 'wallet')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `category`; known values are ('ach', 'charity', 'instant_debit_transfer', 'merchant_card', 'paypal', 'venmo', 'visa_card', 'cash_app', 'international_bank', 'wallet'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('subcategory')
@@ -67,7 +68,7 @@ class ListProductsResponseProductsInner(BaseModel):
             return value
 
         if value not in set(['beauty_and_health', 'digital_financial_services', 'electronics', 'entertainment', 'fashion', 'food_and_drink', 'general_merchandise', 'grocery_and_supermarkets', 'home_and_living', 'mobility_and_fuel', 'sports_and_outdoor_gear', 'travel_and_hospitality']):
-            raise ValueError("must be one of enum values ('beauty_and_health', 'digital_financial_services', 'electronics', 'entertainment', 'fashion', 'food_and_drink', 'general_merchandise', 'grocery_and_supermarkets', 'home_and_living', 'mobility_and_fuel', 'sports_and_outdoor_gear', 'travel_and_hospitality')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `subcategory`; known values are ('beauty_and_health', 'digital_financial_services', 'electronics', 'entertainment', 'fashion', 'food_and_drink', 'general_merchandise', 'grocery_and_supermarkets', 'home_and_living', 'mobility_and_fuel', 'sports_and_outdoor_gear', 'travel_and_hospitality'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('currency_codes')
@@ -75,7 +76,7 @@ class ListProductsResponseProductsInner(BaseModel):
         """Validates the enum"""
         for i in value:
             if i not in set(['USD', 'CAD', 'EUR', 'AED', 'AFN', 'ALL', 'AMD', 'ARS', 'AUD', 'AZN', 'BAM', 'BDT', 'BHD', 'BIF', 'BND', 'BOB', 'BRL', 'BWP', 'BYN', 'BZD', 'CDF', 'CHF', 'CLP', 'CNY', 'COP', 'CRC', 'CVE', 'CZK', 'DJF', 'DKK', 'DOP', 'DZD', 'EGP', 'ERN', 'ETB', 'GBP', 'GEL', 'GHS', 'GNF', 'GTQ', 'HKD', 'HNL', 'HRK', 'HUF', 'IDR', 'ILS', 'INR', 'IQD', 'IRR', 'ISK', 'JMD', 'JOD', 'JPY', 'KES', 'KHR', 'KRW', 'KWD', 'KZT', 'LBP', 'LKR', 'MAD', 'MDL', 'MGA', 'MKD', 'MMK', 'MOP', 'MUR', 'MXN', 'MYR', 'MZN', 'NAD', 'NGN', 'NIO', 'NOK', 'NPR', 'NZD', 'OMR', 'PAB', 'PEN', 'PHP', 'PKR', 'PLN', 'PYG', 'QAR', 'RON', 'RSD', 'RUB', 'RWF', 'SAR', 'SDG', 'SEK', 'SGD', 'SOS', 'SYP', 'THB', 'TND', 'TOP', 'TRY', 'TTD', 'TWD', 'TZS', 'UAH', 'UGX', 'UYU', 'UZS', 'VEF', 'VND', 'XAF', 'XOF', 'YER', 'ZAR']):
-                raise ValueError("each list item must be one of ('USD', 'CAD', 'EUR', 'AED', 'AFN', 'ALL', 'AMD', 'ARS', 'AUD', 'AZN', 'BAM', 'BDT', 'BHD', 'BIF', 'BND', 'BOB', 'BRL', 'BWP', 'BYN', 'BZD', 'CDF', 'CHF', 'CLP', 'CNY', 'COP', 'CRC', 'CVE', 'CZK', 'DJF', 'DKK', 'DOP', 'DZD', 'EGP', 'ERN', 'ETB', 'GBP', 'GEL', 'GHS', 'GNF', 'GTQ', 'HKD', 'HNL', 'HRK', 'HUF', 'IDR', 'ILS', 'INR', 'IQD', 'IRR', 'ISK', 'JMD', 'JOD', 'JPY', 'KES', 'KHR', 'KRW', 'KWD', 'KZT', 'LBP', 'LKR', 'MAD', 'MDL', 'MGA', 'MKD', 'MMK', 'MOP', 'MUR', 'MXN', 'MYR', 'MZN', 'NAD', 'NGN', 'NIO', 'NOK', 'NPR', 'NZD', 'OMR', 'PAB', 'PEN', 'PHP', 'PKR', 'PLN', 'PYG', 'QAR', 'RON', 'RSD', 'RUB', 'RWF', 'SAR', 'SDG', 'SEK', 'SGD', 'SOS', 'SYP', 'THB', 'TND', 'TOP', 'TRY', 'TTD', 'TWD', 'TZS', 'UAH', 'UGX', 'UYU', 'UZS', 'VEF', 'VND', 'XAF', 'XOF', 'YER', 'ZAR')")
+                warnings.warn(f"Unrecognized value '{i}' in enum list field `currency_codes`; known values are ('USD', 'CAD', 'EUR', 'AED', 'AFN', 'ALL', 'AMD', 'ARS', 'AUD', 'AZN', 'BAM', 'BDT', 'BHD', 'BIF', 'BND', 'BOB', 'BRL', 'BWP', 'BYN', 'BZD', 'CDF', 'CHF', 'CLP', 'CNY', 'COP', 'CRC', 'CVE', 'CZK', 'DJF', 'DKK', 'DOP', 'DZD', 'EGP', 'ERN', 'ETB', 'GBP', 'GEL', 'GHS', 'GNF', 'GTQ', 'HKD', 'HNL', 'HRK', 'HUF', 'IDR', 'ILS', 'INR', 'IQD', 'IRR', 'ISK', 'JMD', 'JOD', 'JPY', 'KES', 'KHR', 'KRW', 'KWD', 'KZT', 'LBP', 'LKR', 'MAD', 'MDL', 'MGA', 'MKD', 'MMK', 'MOP', 'MUR', 'MXN', 'MYR', 'MZN', 'NAD', 'NGN', 'NIO', 'NOK', 'NPR', 'NZD', 'OMR', 'PAB', 'PEN', 'PHP', 'PKR', 'PLN', 'PYG', 'QAR', 'RON', 'RSD', 'RUB', 'RWF', 'SAR', 'SDG', 'SEK', 'SGD', 'SOS', 'SYP', 'THB', 'TND', 'TOP', 'TRY', 'TTD', 'TWD', 'TZS', 'UAH', 'UGX', 'UYU', 'UZS', 'VEF', 'VND', 'XAF', 'XOF', 'YER', 'ZAR'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/list_products_response_products_inner_countries_inner.py
+++ b/tremendous/models/list_products_response_products_inner_countries_inner.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/list_products_response_products_inner_documents.py
+++ b/tremendous/models/list_products_response_products_inner_documents.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/list_products_response_products_inner_images_inner.py
+++ b/tremendous/models/list_products_response_products_inner_images_inner.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
@@ -36,7 +37,7 @@ class ListProductsResponseProductsInnerImagesInner(BaseModel):
     def type_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['card', 'logo']):
-            raise ValueError("must be one of enum values ('card', 'logo')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `type`; known values are ('card', 'logo'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/list_products_response_products_inner_skus_inner.py
+++ b/tremendous/models/list_products_response_products_inner_skus_inner.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field
 from typing import Any, ClassVar, Dict, List, Union

--- a/tremendous/models/list_rewards200_response.py
+++ b/tremendous/models/list_rewards200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictInt
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/list_rewards200_response_rewards_inner.py
+++ b/tremendous/models/list_rewards200_response_rewards_inner.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import date, datetime
 from pydantic import BaseModel, ConfigDict, Field, field_validator

--- a/tremendous/models/list_rewards200_response_rewards_inner_custom_fields_inner.py
+++ b/tremendous/models/list_rewards200_response_rewards_inner_custom_fields_inner.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/list_rewards200_response_rewards_inner_delivery.py
+++ b/tremendous/models/list_rewards200_response_rewards_inner_delivery.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
@@ -38,7 +39,7 @@ class ListRewards200ResponseRewardsInnerDelivery(BaseModel):
             return value
 
         if value not in set(['EMAIL', 'LINK', 'PHONE']):
-            raise ValueError("must be one of enum values ('EMAIL', 'LINK', 'PHONE')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `method`; known values are ('EMAIL', 'LINK', 'PHONE'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('status')
@@ -48,7 +49,7 @@ class ListRewards200ResponseRewardsInnerDelivery(BaseModel):
             return value
 
         if value not in set(['SCHEDULED', 'FAILED', 'SUCCEEDED', 'PENDING']):
-            raise ValueError("must be one of enum values ('SCHEDULED', 'FAILED', 'SUCCEEDED', 'PENDING')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('SCHEDULED', 'FAILED', 'SUCCEEDED', 'PENDING'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/list_rewards200_response_rewards_inner_recipient.py
+++ b/tremendous/models/list_rewards200_response_rewards_inner_recipient.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/list_rewards200_response_rewards_inner_value.py
+++ b/tremendous/models/list_rewards200_response_rewards_inner_value.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional, Union
@@ -38,7 +39,7 @@ class ListRewards200ResponseRewardsInnerValue(BaseModel):
             return value
 
         if value not in set(['USD', 'CAD', 'EUR', 'AED', 'AFN', 'ALL', 'AMD', 'ARS', 'AUD', 'AZN', 'BAM', 'BDT', 'BHD', 'BIF', 'BND', 'BOB', 'BRL', 'BWP', 'BYN', 'BZD', 'CDF', 'CHF', 'CLP', 'CNY', 'COP', 'CRC', 'CVE', 'CZK', 'DJF', 'DKK', 'DOP', 'DZD', 'EGP', 'ERN', 'ETB', 'GBP', 'GEL', 'GHS', 'GNF', 'GTQ', 'HKD', 'HNL', 'HRK', 'HUF', 'IDR', 'ILS', 'INR', 'IQD', 'IRR', 'ISK', 'JMD', 'JOD', 'JPY', 'KES', 'KHR', 'KRW', 'KWD', 'KZT', 'LBP', 'LKR', 'MAD', 'MDL', 'MGA', 'MKD', 'MMK', 'MOP', 'MUR', 'MXN', 'MYR', 'MZN', 'NAD', 'NGN', 'NIO', 'NOK', 'NPR', 'NZD', 'OMR', 'PAB', 'PEN', 'PHP', 'PKR', 'PLN', 'PYG', 'QAR', 'RON', 'RSD', 'RUB', 'RWF', 'SAR', 'SDG', 'SEK', 'SGD', 'SOS', 'SYP', 'THB', 'TND', 'TOP', 'TRY', 'TTD', 'TWD', 'TZS', 'UAH', 'UGX', 'UYU', 'UZS', 'VEF', 'VND', 'XAF', 'XOF', 'YER', 'ZAR']):
-            raise ValueError("must be one of enum values ('USD', 'CAD', 'EUR', 'AED', 'AFN', 'ALL', 'AMD', 'ARS', 'AUD', 'AZN', 'BAM', 'BDT', 'BHD', 'BIF', 'BND', 'BOB', 'BRL', 'BWP', 'BYN', 'BZD', 'CDF', 'CHF', 'CLP', 'CNY', 'COP', 'CRC', 'CVE', 'CZK', 'DJF', 'DKK', 'DOP', 'DZD', 'EGP', 'ERN', 'ETB', 'GBP', 'GEL', 'GHS', 'GNF', 'GTQ', 'HKD', 'HNL', 'HRK', 'HUF', 'IDR', 'ILS', 'INR', 'IQD', 'IRR', 'ISK', 'JMD', 'JOD', 'JPY', 'KES', 'KHR', 'KRW', 'KWD', 'KZT', 'LBP', 'LKR', 'MAD', 'MDL', 'MGA', 'MKD', 'MMK', 'MOP', 'MUR', 'MXN', 'MYR', 'MZN', 'NAD', 'NGN', 'NIO', 'NOK', 'NPR', 'NZD', 'OMR', 'PAB', 'PEN', 'PHP', 'PKR', 'PLN', 'PYG', 'QAR', 'RON', 'RSD', 'RUB', 'RWF', 'SAR', 'SDG', 'SEK', 'SGD', 'SOS', 'SYP', 'THB', 'TND', 'TOP', 'TRY', 'TTD', 'TWD', 'TZS', 'UAH', 'UGX', 'UYU', 'UZS', 'VEF', 'VND', 'XAF', 'XOF', 'YER', 'ZAR')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `currency_code`; known values are ('USD', 'CAD', 'EUR', 'AED', 'AFN', 'ALL', 'AMD', 'ARS', 'AUD', 'AZN', 'BAM', 'BDT', 'BHD', 'BIF', 'BND', 'BOB', 'BRL', 'BWP', 'BYN', 'BZD', 'CDF', 'CHF', 'CLP', 'CNY', 'COP', 'CRC', 'CVE', 'CZK', 'DJF', 'DKK', 'DOP', 'DZD', 'EGP', 'ERN', 'ETB', 'GBP', 'GEL', 'GHS', 'GNF', 'GTQ', 'HKD', 'HNL', 'HRK', 'HUF', 'IDR', 'ILS', 'INR', 'IQD', 'IRR', 'ISK', 'JMD', 'JOD', 'JPY', 'KES', 'KHR', 'KRW', 'KWD', 'KZT', 'LBP', 'LKR', 'MAD', 'MDL', 'MGA', 'MKD', 'MMK', 'MOP', 'MUR', 'MXN', 'MYR', 'MZN', 'NAD', 'NGN', 'NIO', 'NOK', 'NPR', 'NZD', 'OMR', 'PAB', 'PEN', 'PHP', 'PKR', 'PLN', 'PYG', 'QAR', 'RON', 'RSD', 'RUB', 'RWF', 'SAR', 'SDG', 'SEK', 'SGD', 'SOS', 'SYP', 'THB', 'TND', 'TOP', 'TRY', 'TTD', 'TWD', 'TZS', 'UAH', 'UGX', 'UYU', 'UZS', 'VEF', 'VND', 'XAF', 'XOF', 'YER', 'ZAR'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/list_rewards401_response.py
+++ b/tremendous/models/list_rewards401_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictInt
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/list_rewards401_response_errors.py
+++ b/tremendous/models/list_rewards401_response_errors.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/list_rewards429_response.py
+++ b/tremendous/models/list_rewards429_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictInt
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/list_roles200_response.py
+++ b/tremendous/models/list_roles200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/list_roles200_response_roles_inner.py
+++ b/tremendous/models/list_roles200_response_roles_inner.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/list_topups200_response.py
+++ b/tremendous/models/list_topups200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictInt
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/list_topups200_response_topups_inner.py
+++ b/tremendous/models/list_topups200_response_topups_inner.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import date, datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr

--- a/tremendous/models/list_webhook_events200_response.py
+++ b/tremendous/models/list_webhook_events200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/list_webhooks200_response.py
+++ b/tremendous/models/list_webhooks200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/list_webhooks200_response_webhooks_inner.py
+++ b/tremendous/models/list_webhooks200_response_webhooks_inner.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/member.py
+++ b/tremendous/models/member.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr, field_validator
@@ -50,7 +51,7 @@ class Member(BaseModel):
     def status_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['REGISTERED', 'INVITED']):
-            raise ValueError("must be one of enum values ('REGISTERED', 'INVITED')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('REGISTERED', 'INVITED'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/member_base.py
+++ b/tremendous/models/member_base.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
@@ -47,7 +48,7 @@ class MemberBase(BaseModel):
     def status_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['REGISTERED', 'INVITED']):
-            raise ValueError("must be one of enum values ('REGISTERED', 'INVITED')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('REGISTERED', 'INVITED'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/member_with_events.py
+++ b/tremendous/models/member_with_events.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
@@ -49,7 +50,7 @@ class MemberWithEvents(BaseModel):
     def status_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['REGISTERED', 'INVITED']):
-            raise ValueError("must be one of enum values ('REGISTERED', 'INVITED')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('REGISTERED', 'INVITED'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/member_without_events.py
+++ b/tremendous/models/member_without_events.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr, field_validator
@@ -50,7 +51,7 @@ class MemberWithoutEvents(BaseModel):
     def status_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['REGISTERED', 'INVITED']):
-            raise ValueError("must be one of enum values ('REGISTERED', 'INVITED')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('REGISTERED', 'INVITED'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/model_field.py
+++ b/tremendous/models/model_field.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
@@ -54,7 +55,7 @@ class ModelField(BaseModel):
             return value
 
         if value not in set(['Checkbox', 'Currency', 'Date', 'Dropdown', 'Email', 'List', 'Number', 'Phone', 'Text', 'TextArea']):
-            raise ValueError("must be one of enum values ('Checkbox', 'Currency', 'Date', 'Dropdown', 'Email', 'List', 'Number', 'Phone', 'Text', 'TextArea')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `data_type`; known values are ('Checkbox', 'Currency', 'Date', 'Dropdown', 'Email', 'List', 'Number', 'Phone', 'Text', 'TextArea'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/order.py
+++ b/tremendous/models/order.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
@@ -63,7 +64,7 @@ class Order(BaseModel):
     def status_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT']):
-            raise ValueError("must be one of enum values ('CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('channel')
@@ -73,7 +74,7 @@ class Order(BaseModel):
             return value
 
         if value not in set(['UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO']):
-            raise ValueError("must be one of enum values ('UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `channel`; known values are ('UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/order_base.py
+++ b/tremendous/models/order_base.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
@@ -61,7 +62,7 @@ class OrderBase(BaseModel):
     def status_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT']):
-            raise ValueError("must be one of enum values ('CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('channel')
@@ -71,7 +72,7 @@ class OrderBase(BaseModel):
             return value
 
         if value not in set(['UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO']):
-            raise ValueError("must be one of enum values ('UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `channel`; known values are ('UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/order_base_payment.py
+++ b/tremendous/models/order_base_payment.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional, Union

--- a/tremendous/models/order_with_link.py
+++ b/tremendous/models/order_with_link.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
@@ -63,7 +64,7 @@ class OrderWithLink(BaseModel):
     def status_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT']):
-            raise ValueError("must be one of enum values ('CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('channel')
@@ -73,7 +74,7 @@ class OrderWithLink(BaseModel):
             return value
 
         if value not in set(['UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO']):
-            raise ValueError("must be one of enum values ('UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `channel`; known values are ('UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/order_with_link_rewards_inner.py
+++ b/tremendous/models/order_with_link_rewards_inner.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import date, datetime
 from pydantic import BaseModel, ConfigDict, Field, field_validator

--- a/tremendous/models/order_without_link.py
+++ b/tremendous/models/order_without_link.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
@@ -63,7 +64,7 @@ class OrderWithoutLink(BaseModel):
     def status_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT']):
-            raise ValueError("must be one of enum values ('CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('channel')
@@ -73,7 +74,7 @@ class OrderWithoutLink(BaseModel):
             return value
 
         if value not in set(['UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO']):
-            raise ValueError("must be one of enum values ('UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `channel`; known values are ('UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/order_without_link_rewards_inner.py
+++ b/tremendous/models/order_without_link_rewards_inner.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import date, datetime
 from pydantic import BaseModel, ConfigDict, Field, field_validator

--- a/tremendous/models/organization.py
+++ b/tremendous/models/organization.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import date
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
@@ -54,7 +55,7 @@ class Organization(BaseModel):
             return value
 
         if value not in set(['PENDING', 'APPROVED', 'REJECTED']):
-            raise ValueError("must be one of enum values ('PENDING', 'APPROVED', 'REJECTED')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('PENDING', 'APPROVED', 'REJECTED'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/payment_details.py
+++ b/tremendous/models/payment_details.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional, Union

--- a/tremendous/models/payment_details_refund.py
+++ b/tremendous/models/payment_details_refund.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Union

--- a/tremendous/models/payout.py
+++ b/tremendous/models/payout.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
@@ -55,7 +56,7 @@ class Payout(BaseModel):
             return value
 
         if value not in set(['UNEXECUTED', 'COMPLETED', 'FAILED', 'CANCELED', 'ORGANIZATION_REVIEW', 'ADMIN_HELD']):
-            raise ValueError("must be one of enum values ('UNEXECUTED', 'COMPLETED', 'FAILED', 'CANCELED', 'ORGANIZATION_REVIEW', 'ADMIN_HELD')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('UNEXECUTED', 'COMPLETED', 'FAILED', 'CANCELED', 'ORGANIZATION_REVIEW', 'ADMIN_HELD'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('product_id')

--- a/tremendous/models/product.py
+++ b/tremendous/models/product.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
@@ -57,7 +58,7 @@ class Product(BaseModel):
     def category_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['ach', 'charity', 'instant_debit_transfer', 'merchant_card', 'paypal', 'venmo', 'visa_card', 'cash_app', 'international_bank', 'wallet']):
-            raise ValueError("must be one of enum values ('ach', 'charity', 'instant_debit_transfer', 'merchant_card', 'paypal', 'venmo', 'visa_card', 'cash_app', 'international_bank', 'wallet')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `category`; known values are ('ach', 'charity', 'instant_debit_transfer', 'merchant_card', 'paypal', 'venmo', 'visa_card', 'cash_app', 'international_bank', 'wallet'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('subcategory')
@@ -67,7 +68,7 @@ class Product(BaseModel):
             return value
 
         if value not in set(['beauty_and_health', 'digital_financial_services', 'electronics', 'entertainment', 'fashion', 'food_and_drink', 'general_merchandise', 'grocery_and_supermarkets', 'home_and_living', 'mobility_and_fuel', 'sports_and_outdoor_gear', 'travel_and_hospitality']):
-            raise ValueError("must be one of enum values ('beauty_and_health', 'digital_financial_services', 'electronics', 'entertainment', 'fashion', 'food_and_drink', 'general_merchandise', 'grocery_and_supermarkets', 'home_and_living', 'mobility_and_fuel', 'sports_and_outdoor_gear', 'travel_and_hospitality')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `subcategory`; known values are ('beauty_and_health', 'digital_financial_services', 'electronics', 'entertainment', 'fashion', 'food_and_drink', 'general_merchandise', 'grocery_and_supermarkets', 'home_and_living', 'mobility_and_fuel', 'sports_and_outdoor_gear', 'travel_and_hospitality'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('currency_codes')
@@ -75,7 +76,7 @@ class Product(BaseModel):
         """Validates the enum"""
         for i in value:
             if i not in set(['USD', 'CAD', 'EUR', 'AED', 'AFN', 'ALL', 'AMD', 'ARS', 'AUD', 'AZN', 'BAM', 'BDT', 'BHD', 'BIF', 'BND', 'BOB', 'BRL', 'BWP', 'BYN', 'BZD', 'CDF', 'CHF', 'CLP', 'CNY', 'COP', 'CRC', 'CVE', 'CZK', 'DJF', 'DKK', 'DOP', 'DZD', 'EGP', 'ERN', 'ETB', 'GBP', 'GEL', 'GHS', 'GNF', 'GTQ', 'HKD', 'HNL', 'HRK', 'HUF', 'IDR', 'ILS', 'INR', 'IQD', 'IRR', 'ISK', 'JMD', 'JOD', 'JPY', 'KES', 'KHR', 'KRW', 'KWD', 'KZT', 'LBP', 'LKR', 'MAD', 'MDL', 'MGA', 'MKD', 'MMK', 'MOP', 'MUR', 'MXN', 'MYR', 'MZN', 'NAD', 'NGN', 'NIO', 'NOK', 'NPR', 'NZD', 'OMR', 'PAB', 'PEN', 'PHP', 'PKR', 'PLN', 'PYG', 'QAR', 'RON', 'RSD', 'RUB', 'RWF', 'SAR', 'SDG', 'SEK', 'SGD', 'SOS', 'SYP', 'THB', 'TND', 'TOP', 'TRY', 'TTD', 'TWD', 'TZS', 'UAH', 'UGX', 'UYU', 'UZS', 'VEF', 'VND', 'XAF', 'XOF', 'YER', 'ZAR']):
-                raise ValueError("each list item must be one of ('USD', 'CAD', 'EUR', 'AED', 'AFN', 'ALL', 'AMD', 'ARS', 'AUD', 'AZN', 'BAM', 'BDT', 'BHD', 'BIF', 'BND', 'BOB', 'BRL', 'BWP', 'BYN', 'BZD', 'CDF', 'CHF', 'CLP', 'CNY', 'COP', 'CRC', 'CVE', 'CZK', 'DJF', 'DKK', 'DOP', 'DZD', 'EGP', 'ERN', 'ETB', 'GBP', 'GEL', 'GHS', 'GNF', 'GTQ', 'HKD', 'HNL', 'HRK', 'HUF', 'IDR', 'ILS', 'INR', 'IQD', 'IRR', 'ISK', 'JMD', 'JOD', 'JPY', 'KES', 'KHR', 'KRW', 'KWD', 'KZT', 'LBP', 'LKR', 'MAD', 'MDL', 'MGA', 'MKD', 'MMK', 'MOP', 'MUR', 'MXN', 'MYR', 'MZN', 'NAD', 'NGN', 'NIO', 'NOK', 'NPR', 'NZD', 'OMR', 'PAB', 'PEN', 'PHP', 'PKR', 'PLN', 'PYG', 'QAR', 'RON', 'RSD', 'RUB', 'RWF', 'SAR', 'SDG', 'SEK', 'SGD', 'SOS', 'SYP', 'THB', 'TND', 'TOP', 'TRY', 'TTD', 'TWD', 'TZS', 'UAH', 'UGX', 'UYU', 'UZS', 'VEF', 'VND', 'XAF', 'XOF', 'YER', 'ZAR')")
+                warnings.warn(f"Unrecognized value '{i}' in enum list field `currency_codes`; known values are ('USD', 'CAD', 'EUR', 'AED', 'AFN', 'ALL', 'AMD', 'ARS', 'AUD', 'AZN', 'BAM', 'BDT', 'BHD', 'BIF', 'BND', 'BOB', 'BRL', 'BWP', 'BYN', 'BZD', 'CDF', 'CHF', 'CLP', 'CNY', 'COP', 'CRC', 'CVE', 'CZK', 'DJF', 'DKK', 'DOP', 'DZD', 'EGP', 'ERN', 'ETB', 'GBP', 'GEL', 'GHS', 'GNF', 'GTQ', 'HKD', 'HNL', 'HRK', 'HUF', 'IDR', 'ILS', 'INR', 'IQD', 'IRR', 'ISK', 'JMD', 'JOD', 'JPY', 'KES', 'KHR', 'KRW', 'KWD', 'KZT', 'LBP', 'LKR', 'MAD', 'MDL', 'MGA', 'MKD', 'MMK', 'MOP', 'MUR', 'MXN', 'MYR', 'MZN', 'NAD', 'NGN', 'NIO', 'NOK', 'NPR', 'NZD', 'OMR', 'PAB', 'PEN', 'PHP', 'PKR', 'PLN', 'PYG', 'QAR', 'RON', 'RSD', 'RUB', 'RWF', 'SAR', 'SDG', 'SEK', 'SGD', 'SOS', 'SYP', 'THB', 'TND', 'TOP', 'TRY', 'TTD', 'TWD', 'TZS', 'UAH', 'UGX', 'UYU', 'UZS', 'VEF', 'VND', 'XAF', 'XOF', 'YER', 'ZAR'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/product_documents.py
+++ b/tremendous/models/product_documents.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/recipient.py
+++ b/tremendous/models/recipient.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/refund_details.py
+++ b/tremendous/models/refund_details.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Union

--- a/tremendous/models/report.py
+++ b/tremendous/models/report.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
@@ -42,7 +43,7 @@ class Report(BaseModel):
             return value
 
         if value not in set(['CREATED', 'PROCESSING', 'READY_FOR_DOWNLOAD', 'FAILED']):
-            raise ValueError("must be one of enum values ('CREATED', 'PROCESSING', 'READY_FOR_DOWNLOAD', 'FAILED')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('CREATED', 'PROCESSING', 'READY_FOR_DOWNLOAD', 'FAILED'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/resend_reward422_response.py
+++ b/tremendous/models/resend_reward422_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictInt
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/resend_reward_request.py
+++ b/tremendous/models/resend_reward_request.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/review_country.py
+++ b/tremendous/models/review_country.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List
@@ -35,7 +36,7 @@ class ReviewCountry(BaseModel):
     def type_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['whitelist', 'blacklist']):
-            raise ValueError("must be one of enum values ('whitelist', 'blacklist')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `type`; known values are ('whitelist', 'blacklist'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/review_country1.py
+++ b/tremendous/models/review_country1.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/review_email.py
+++ b/tremendous/models/review_email.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/review_email1.py
+++ b/tremendous/models/review_email1.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/review_ip.py
+++ b/tremendous/models/review_ip.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/review_ip1.py
+++ b/tremendous/models/review_ip1.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/review_redeemed_rewards_amount.py
+++ b/tremendous/models/review_redeemed_rewards_amount.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Union
@@ -36,7 +37,7 @@ class ReviewRedeemedRewardsAmount(BaseModel):
     def period_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['7', '30', '90', '120', '365', 'all_time']):
-            raise ValueError("must be one of enum values ('7', '30', '90', '120', '365', 'all_time')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `period`; known values are ('7', '30', '90', '120', '365', 'all_time'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/review_redeemed_rewards_count.py
+++ b/tremendous/models/review_redeemed_rewards_count.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List
@@ -36,7 +37,7 @@ class ReviewRedeemedRewardsCount(BaseModel):
     def period_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['7', '30', '90', '120', '365', 'all_time']):
-            raise ValueError("must be one of enum values ('7', '30', '90', '120', '365', 'all_time')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `period`; known values are ('7', '30', '90', '120', '365', 'all_time'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/review_vpn.py
+++ b/tremendous/models/review_vpn.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictBool
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/reward.py
+++ b/tremendous/models/reward.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import date, datetime
 from pydantic import BaseModel, ConfigDict, Field, field_validator

--- a/tremendous/models/reward_base.py
+++ b/tremendous/models/reward_base.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import date, datetime
 from pydantic import BaseModel, ConfigDict, Field, field_validator

--- a/tremendous/models/reward_base_custom_fields_inner.py
+++ b/tremendous/models/reward_base_custom_fields_inner.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/reward_for_order_create.py
+++ b/tremendous/models/reward_for_order_create.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import date, datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator

--- a/tremendous/models/reward_link.py
+++ b/tremendous/models/reward_link.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/reward_token.py
+++ b/tremendous/models/reward_token.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator

--- a/tremendous/models/reward_value.py
+++ b/tremendous/models/reward_value.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional, Union
@@ -38,7 +39,7 @@ class RewardValue(BaseModel):
             return value
 
         if value not in set(['USD', 'CAD', 'EUR', 'AED', 'AFN', 'ALL', 'AMD', 'ARS', 'AUD', 'AZN', 'BAM', 'BDT', 'BHD', 'BIF', 'BND', 'BOB', 'BRL', 'BWP', 'BYN', 'BZD', 'CDF', 'CHF', 'CLP', 'CNY', 'COP', 'CRC', 'CVE', 'CZK', 'DJF', 'DKK', 'DOP', 'DZD', 'EGP', 'ERN', 'ETB', 'GBP', 'GEL', 'GHS', 'GNF', 'GTQ', 'HKD', 'HNL', 'HRK', 'HUF', 'IDR', 'ILS', 'INR', 'IQD', 'IRR', 'ISK', 'JMD', 'JOD', 'JPY', 'KES', 'KHR', 'KRW', 'KWD', 'KZT', 'LBP', 'LKR', 'MAD', 'MDL', 'MGA', 'MKD', 'MMK', 'MOP', 'MUR', 'MXN', 'MYR', 'MZN', 'NAD', 'NGN', 'NIO', 'NOK', 'NPR', 'NZD', 'OMR', 'PAB', 'PEN', 'PHP', 'PKR', 'PLN', 'PYG', 'QAR', 'RON', 'RSD', 'RUB', 'RWF', 'SAR', 'SDG', 'SEK', 'SGD', 'SOS', 'SYP', 'THB', 'TND', 'TOP', 'TRY', 'TTD', 'TWD', 'TZS', 'UAH', 'UGX', 'UYU', 'UZS', 'VEF', 'VND', 'XAF', 'XOF', 'YER', 'ZAR']):
-            raise ValueError("must be one of enum values ('USD', 'CAD', 'EUR', 'AED', 'AFN', 'ALL', 'AMD', 'ARS', 'AUD', 'AZN', 'BAM', 'BDT', 'BHD', 'BIF', 'BND', 'BOB', 'BRL', 'BWP', 'BYN', 'BZD', 'CDF', 'CHF', 'CLP', 'CNY', 'COP', 'CRC', 'CVE', 'CZK', 'DJF', 'DKK', 'DOP', 'DZD', 'EGP', 'ERN', 'ETB', 'GBP', 'GEL', 'GHS', 'GNF', 'GTQ', 'HKD', 'HNL', 'HRK', 'HUF', 'IDR', 'ILS', 'INR', 'IQD', 'IRR', 'ISK', 'JMD', 'JOD', 'JPY', 'KES', 'KHR', 'KRW', 'KWD', 'KZT', 'LBP', 'LKR', 'MAD', 'MDL', 'MGA', 'MKD', 'MMK', 'MOP', 'MUR', 'MXN', 'MYR', 'MZN', 'NAD', 'NGN', 'NIO', 'NOK', 'NPR', 'NZD', 'OMR', 'PAB', 'PEN', 'PHP', 'PKR', 'PLN', 'PYG', 'QAR', 'RON', 'RSD', 'RUB', 'RWF', 'SAR', 'SDG', 'SEK', 'SGD', 'SOS', 'SYP', 'THB', 'TND', 'TOP', 'TRY', 'TTD', 'TWD', 'TZS', 'UAH', 'UGX', 'UYU', 'UZS', 'VEF', 'VND', 'XAF', 'XOF', 'YER', 'ZAR')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `currency_code`; known values are ('USD', 'CAD', 'EUR', 'AED', 'AFN', 'ALL', 'AMD', 'ARS', 'AUD', 'AZN', 'BAM', 'BDT', 'BHD', 'BIF', 'BND', 'BOB', 'BRL', 'BWP', 'BYN', 'BZD', 'CDF', 'CHF', 'CLP', 'CNY', 'COP', 'CRC', 'CVE', 'CZK', 'DJF', 'DKK', 'DOP', 'DZD', 'EGP', 'ERN', 'ETB', 'GBP', 'GEL', 'GHS', 'GNF', 'GTQ', 'HKD', 'HNL', 'HRK', 'HUF', 'IDR', 'ILS', 'INR', 'IQD', 'IRR', 'ISK', 'JMD', 'JOD', 'JPY', 'KES', 'KHR', 'KRW', 'KWD', 'KZT', 'LBP', 'LKR', 'MAD', 'MDL', 'MGA', 'MKD', 'MMK', 'MOP', 'MUR', 'MXN', 'MYR', 'MZN', 'NAD', 'NGN', 'NIO', 'NOK', 'NPR', 'NZD', 'OMR', 'PAB', 'PEN', 'PHP', 'PKR', 'PLN', 'PYG', 'QAR', 'RON', 'RSD', 'RUB', 'RWF', 'SAR', 'SDG', 'SEK', 'SGD', 'SOS', 'SYP', 'THB', 'TND', 'TOP', 'TRY', 'TTD', 'TWD', 'TZS', 'UAH', 'UGX', 'UYU', 'UZS', 'VEF', 'VND', 'XAF', 'XOF', 'YER', 'ZAR'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/reward_with_link.py
+++ b/tremendous/models/reward_with_link.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import date, datetime
 from pydantic import BaseModel, ConfigDict, Field, field_validator

--- a/tremendous/models/reward_with_link_delivery.py
+++ b/tremendous/models/reward_with_link_delivery.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
@@ -36,14 +37,14 @@ class RewardWithLinkDelivery(BaseModel):
     def method_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['EMAIL', 'LINK', 'PHONE']):
-            raise ValueError("must be one of enum values ('EMAIL', 'LINK', 'PHONE')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `method`; known values are ('EMAIL', 'LINK', 'PHONE'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('status')
     def status_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['SCHEDULED', 'FAILED', 'SUCCEEDED', 'PENDING']):
-            raise ValueError("must be one of enum values ('SCHEDULED', 'FAILED', 'SUCCEEDED', 'PENDING')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('SCHEDULED', 'FAILED', 'SUCCEEDED', 'PENDING'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/reward_without_link.py
+++ b/tremendous/models/reward_without_link.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import date, datetime
 from pydantic import BaseModel, ConfigDict, Field, field_validator

--- a/tremendous/models/reward_without_link_delivery.py
+++ b/tremendous/models/reward_without_link_delivery.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
@@ -38,7 +39,7 @@ class RewardWithoutLinkDelivery(BaseModel):
             return value
 
         if value not in set(['EMAIL', 'LINK', 'PHONE']):
-            raise ValueError("must be one of enum values ('EMAIL', 'LINK', 'PHONE')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `method`; known values are ('EMAIL', 'LINK', 'PHONE'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('status')
@@ -48,7 +49,7 @@ class RewardWithoutLinkDelivery(BaseModel):
             return value
 
         if value not in set(['SCHEDULED', 'FAILED', 'SUCCEEDED', 'PENDING']):
-            raise ValueError("must be one of enum values ('SCHEDULED', 'FAILED', 'SUCCEEDED', 'PENDING')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('SCHEDULED', 'FAILED', 'SUCCEEDED', 'PENDING'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/role.py
+++ b/tremendous/models/role.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/simulate_webhook_request.py
+++ b/tremendous/models/simulate_webhook_request.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/single_reward_order.py
+++ b/tremendous/models/single_reward_order.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/single_reward_order_payment.py
+++ b/tremendous/models/single_reward_order_payment.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/single_reward_order_reward.py
+++ b/tremendous/models/single_reward_order_reward.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import date
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator

--- a/tremendous/models/single_reward_order_reward_custom_fields_inner.py
+++ b/tremendous/models/single_reward_order_reward_custom_fields_inner.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/single_reward_order_reward_delivery.py
+++ b/tremendous/models/single_reward_order_reward_delivery.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
@@ -39,7 +40,7 @@ class SingleRewardOrderRewardDelivery(BaseModel):
             return value
 
         if value not in set(['EMAIL', 'LINK', 'PHONE']):
-            raise ValueError("must be one of enum values ('EMAIL', 'LINK', 'PHONE')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `method`; known values are ('EMAIL', 'LINK', 'PHONE'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/single_reward_order_reward_delivery_meta.py
+++ b/tremendous/models/single_reward_order_reward_delivery_meta.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/single_reward_order_with_link.py
+++ b/tremendous/models/single_reward_order_with_link.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/single_reward_order_with_link_order.py
+++ b/tremendous/models/single_reward_order_with_link_order.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
@@ -63,7 +64,7 @@ class SingleRewardOrderWithLinkOrder(BaseModel):
     def status_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT']):
-            raise ValueError("must be one of enum values ('CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('channel')
@@ -73,7 +74,7 @@ class SingleRewardOrderWithLinkOrder(BaseModel):
             return value
 
         if value not in set(['UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO']):
-            raise ValueError("must be one of enum values ('UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `channel`; known values are ('UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/single_reward_order_without_link.py
+++ b/tremendous/models/single_reward_order_without_link.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/single_reward_order_without_link_order.py
+++ b/tremendous/models/single_reward_order_without_link_order.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
@@ -63,7 +64,7 @@ class SingleRewardOrderWithoutLinkOrder(BaseModel):
     def status_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT']):
-            raise ValueError("must be one of enum values ('CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `status`; known values are ('CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     @field_validator('channel')
@@ -73,7 +74,7 @@ class SingleRewardOrderWithoutLinkOrder(BaseModel):
             return value
 
         if value not in set(['UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO']):
-            raise ValueError("must be one of enum values ('UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `channel`; known values are ('UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/topup.py
+++ b/tremendous/models/topup.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from datetime import date, datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr

--- a/tremendous/models/topup_create_request.py
+++ b/tremendous/models/topup_create_request.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr
 from typing import Any, ClassVar, Dict, List, Union

--- a/tremendous/models/update_campaign.py
+++ b/tremendous/models/update_campaign.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
@@ -58,7 +59,7 @@ class UpdateCampaign(BaseModel):
             return value
 
         if value not in set(['SENDER', 'RECIPIENT']):
-            raise ValueError("must be one of enum values ('SENDER', 'RECIPIENT')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `fee_charged_to`; known values are ('SENDER', 'RECIPIENT'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/update_campaign_request.py
+++ b/tremendous/models/update_campaign_request.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
@@ -47,7 +48,7 @@ class UpdateCampaignRequest(BaseModel):
             return value
 
         if value not in set(['SENDER', 'RECIPIENT']):
-            raise ValueError("must be one of enum values ('SENDER', 'RECIPIENT')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `fee_charged_to`; known values are ('SENDER', 'RECIPIENT'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/update_fraud_rule_list200_response.py
+++ b/tremendous/models/update_fraud_rule_list200_response.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List

--- a/tremendous/models/update_fraud_rule_list_request.py
+++ b/tremendous/models/update_fraud_rule_list_request.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List
@@ -36,7 +37,7 @@ class UpdateFraudRuleListRequest(BaseModel):
     def operation_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['add', 'remove']):
-            raise ValueError("must be one of enum values ('add', 'remove')")
+            warnings.warn(f"Unrecognized value '{value}' for enum field `operation`; known values are ('add', 'remove'). The API may have added values unknown to this version of the SDK; consider upgrading tremendous-python.", stacklevel=2)
         return value
 
     model_config = ConfigDict(

--- a/tremendous/models/webhook.py
+++ b/tremendous/models/webhook.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional

--- a/tremendous/models/webhook_post.py
+++ b/tremendous/models/webhook_post.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import warnings  # noqa: F401
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List


### PR DESCRIPTION
## Summary
Fixes #129

A user on tremendous-python 5.9.0 reported that `list_products` raises a pydantic `ValidationError` because the API now returns products with `category: "wallet"`, a value added to the spec in June ([91603e7](https://github.com/tremendous-rewards/tremendous-python/commit/91603e75e809ae494ba0c1c90f62bf50624c63b3), released in 5.18.0). Upgrading fixes their immediate problem, but the failure mode is systemic: the generated models validate enums strictly at parse time, so [a single unknown enum value](https://github.com/tremendous-rewards/tremendous-python/blob/af57904fec7c0dc869a65812442b6eab5710f258/tremendous/models/list_products_response_products_inner.py#L59-L60) fails the entire response. Every time the API adds an enum value, which happens in most releases (product categories, fraud reasons, statuses), every previously released version of this SDK starts breaking at runtime.

This is specific to the Python SDK: the Ruby generator, for instance, doesn't validate enums during deserialization.

## Solution
We already pass custom templates to the generator in [`bin/generate`](https://github.com/tremendous-rewards/tremendous-python/blob/main/bin/generate#L22), so I copied `model_generic.mustache` from upstream openapi-generator v7.12.0 (the version we pin) into `templates/python/` and changed the enum field validators to emit a `UserWarning` instead of raising. Unknown values are accepted and preserved as plain strings, and the warning tells the user to upgrade. The bulk of the diff is the regenerated models; every changed line is either the new `import warnings` or the validator swap. Future regenerations, including the scheduled update-sdk workflow, will keep this behavior since they go through the same template.

Two trade-offs to be aware of:

* Request models share the same template, so sending an invalid enum value in a request now warns client-side instead of raising, and the API rejects it with a 422 as the source of truth.
* The template is a full copy of the upstream one, so whenever we bump the generator version we need to re-sync it and re-apply this patch. Same maintenance cost as the other templates we already override.

I also added unit tests for this in `test/test_enum_tolerance.py`. Unlike the rest of the suite they don't need sandbox credentials, they just parse canned JSON.

I considered the generator's `enumUnknownDefaultCase` option, but it doesn't affect these inline field validators in the python generator. Removing enums from response schemas in the spec would also work, but it ripples into the docs and the other SDKs. Let me know what you think!