### PR TITLE
fix: tolerate unknown enum values in API responses

### DIFF
--- a/templates/python/model_generic.mustache.patch
+++ b/templates/python/model_generic.mustache.patch
@@ -1,0 +1,45 @@
+--- model_generic.mustache (openapi-generator v7.12.0)
++++ model_generic.mustache (tremendous)
+@@ -56,41 +56,7 @@
+             raise ValueError(r"must validate the regular expression {{{vendorExtensions.x-pattern}}}")
+         return value
+     {{/vendorExtensions.x-regex}}
+-    {{#isEnum}}
+-
+-    @field_validator('{{{name}}}')
+-    def {{{name}}}_validate_enum(cls, value):
+-        """Validates the enum"""
+-        {{^required}}
+-        if value is None:
+-            return value
+-
+-        {{/required}}
+-        {{#required}}
+-        {{#isNullable}}
+-        if value is None:
+-            return value
+-
+-        {{/isNullable}}
+-        {{/required}}
+-        {{#isContainer}}
+-        {{#isArray}}
+-        for i in value:
+-            if i not in set([{{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}}]):
+-                raise ValueError("each list item must be one of ({{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}})")
+-        {{/isArray}}
+-        {{#isMap}}
+-        for i in value.values():
+-            if i not in set([{{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}}]):
+-                raise ValueError("dict values must be one of enum values ({{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}})")
+-        {{/isMap}}
+-        {{/isContainer}}
+-        {{^isContainer}}
+-        if value not in set([{{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}}]):
+-            raise ValueError("must be one of enum values ({{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}})")
+-        {{/isContainer}}
+-        return value
+-    {{/isEnum}}
++    {{! Edited by Tremendous: enum membership is not validated, so enum values added to the API do not break deserialization on older versions of this package. Type and required checks still come from pydantic. !}}
+ {{/vars}}
+ 
+     model_config = ConfigDict(

--- a/test/test_enum_tolerance.py
+++ b/test/test_enum_tolerance.py
@@ -1,0 +1,40 @@
+import pytest
+from pydantic import ValidationError
+
+from tremendous import ListProductsResponseProductsInner
+
+
+# Responses with enum values unknown to this SDK version must not fail parsing.
+# The API adds enum values (product categories, fraud reasons, statuses) in
+# most releases, and previously released versions of the SDK must keep working
+# when they encounter them.
+class TestEnumTolerance:
+  def product_attributes(self, **overrides):
+    attributes = {
+      "id": "ABCD1234",
+      "name": "Test Product",
+      "description": "A test product",
+      "category": "merchant_card",
+      "disclosure": "",
+      "currency_codes": ["USD"],
+      "countries": [{"abbr": "US"}],
+      "images": [],
+    }
+    attributes.update(overrides)
+    return attributes
+
+  def test_parses_known_enum_values(self):
+    product = ListProductsResponseProductsInner.from_dict(self.product_attributes())
+
+    assert product.category == "merchant_card"
+
+  def test_parses_unknown_enum_values_preserving_the_raw_value(self):
+    product = ListProductsResponseProductsInner.from_dict(
+      self.product_attributes(category="a_category_added_in_the_future")
+    )
+
+    assert product.category == "a_category_added_in_the_future"
+
+  def test_still_rejects_a_missing_required_enum_value(self):
+    with pytest.raises(ValidationError, match="category"):
+      ListProductsResponseProductsInner.from_dict(self.product_attributes(category=None))

--- a/tremendous/models/campaign.py
+++ b/tremendous/models/campaign.py
@@ -51,16 +51,6 @@ class Campaign(BaseModel):
             raise ValueError(r"must validate the regular expression /[A-Z0-9]{4,20}/")
         return value
 
-    @field_validator('fee_charged_to')
-    def fee_charged_to_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['SENDER', 'RECIPIENT']):
-            raise ValueError("must be one of enum values ('SENDER', 'RECIPIENT')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/campaign_base.py
+++ b/tremendous/models/campaign_base.py
@@ -51,16 +51,6 @@ class CampaignBase(BaseModel):
             raise ValueError(r"must validate the regular expression /[A-Z0-9]{4,20}/")
         return value
 
-    @field_validator('fee_charged_to')
-    def fee_charged_to_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['SENDER', 'RECIPIENT']):
-            raise ValueError("must be one of enum values ('SENDER', 'RECIPIENT')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/connected_organization_member_member.py
+++ b/tremendous/models/connected_organization_member_member.py
@@ -46,13 +46,6 @@ class ConnectedOrganizationMemberMember(BaseModel):
             raise ValueError(r"must validate the regular expression /[A-Z0-9]{4,20}/")
         return value
 
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['REGISTERED', 'INVITED']):
-            raise ValueError("must be one of enum values ('REGISTERED', 'INVITED')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/connected_organization_organization.py
+++ b/tremendous/models/connected_organization_organization.py
@@ -47,16 +47,6 @@ class ConnectedOrganizationOrganization(BaseModel):
             raise ValueError(r"must validate the regular expression /[A-Z0-9]{4,20}/")
         return value
 
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['PENDING', 'APPROVED', 'REJECTED']):
-            raise ValueError("must be one of enum values ('PENDING', 'APPROVED', 'REJECTED')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/create_campaign_request.py
+++ b/tremendous/models/create_campaign_request.py
@@ -40,16 +40,6 @@ class CreateCampaignRequest(BaseModel):
     email_style: Optional[ListCampaigns200ResponseCampaignsInnerEmailStyle] = None
     __properties: ClassVar[List[str]] = ["name", "description", "products", "fee_charged_to", "auto_add_product_rule", "webpage_style", "email_style"]
 
-    @field_validator('fee_charged_to')
-    def fee_charged_to_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['SENDER', 'RECIPIENT']):
-            raise ValueError("must be one of enum values ('SENDER', 'RECIPIENT')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/create_field.py
+++ b/tremendous/models/create_field.py
@@ -35,13 +35,6 @@ class CreateField(BaseModel):
     description: Optional[StrictStr] = Field(default=None, description="A description of the field's purpose")
     __properties: ClassVar[List[str]] = ["display_name", "data_type", "data", "required", "description"]
 
-    @field_validator('data_type')
-    def data_type_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['Checkbox', 'Currency', 'Date', 'Dropdown', 'Email', 'List', 'Number', 'Phone', 'Text', 'TextArea']):
-            raise ValueError("must be one of enum values ('Checkbox', 'Currency', 'Date', 'Dropdown', 'Email', 'List', 'Number', 'Phone', 'Text', 'TextArea')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/create_field_request.py
+++ b/tremendous/models/create_field_request.py
@@ -35,13 +35,6 @@ class CreateFieldRequest(BaseModel):
     description: Optional[StrictStr] = Field(default=None, description="A description of the field's purpose")
     __properties: ClassVar[List[str]] = ["display_name", "data_type", "data", "required", "description"]
 
-    @field_validator('data_type')
-    def data_type_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['Checkbox', 'Currency', 'Date', 'Dropdown', 'Email', 'List', 'Number', 'Phone', 'Text', 'TextArea']):
-            raise ValueError("must be one of enum values ('Checkbox', 'Currency', 'Date', 'Dropdown', 'Email', 'List', 'Number', 'Phone', 'Text', 'TextArea')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/create_invoice_request.py
+++ b/tremendous/models/create_invoice_request.py
@@ -34,26 +34,6 @@ class CreateInvoiceRequest(BaseModel):
     memo: Optional[StrictStr] = Field(default=None, description="A note to be included in the invoice. This is for your internal use and will not be visible to the recipient. ")
     __properties: ClassVar[List[str]] = ["po_number", "amount", "currency_code", "currency", "memo"]
 
-    @field_validator('currency_code')
-    def currency_code_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['USD', 'EUR', 'GBP']):
-            raise ValueError("must be one of enum values ('USD', 'EUR', 'GBP')")
-        return value
-
-    @field_validator('currency')
-    def currency_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['USD', 'EUR', 'GBP']):
-            raise ValueError("must be one of enum values ('USD', 'EUR', 'GBP')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/create_order200_response_order.py
+++ b/tremendous/models/create_order200_response_order.py
@@ -59,23 +59,6 @@ class CreateOrder200ResponseOrder(BaseModel):
             raise ValueError(r"must validate the regular expression /[A-Z0-9]{4,20}/")
         return value
 
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT']):
-            raise ValueError("must be one of enum values ('CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT')")
-        return value
-
-    @field_validator('channel')
-    def channel_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO']):
-            raise ValueError("must be one of enum values ('UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/create_order200_response_order_rewards_inner_delivery.py
+++ b/tremendous/models/create_order200_response_order_rewards_inner_delivery.py
@@ -32,20 +32,6 @@ class CreateOrder200ResponseOrderRewardsInnerDelivery(BaseModel):
     link: Optional[StrictStr] = Field(default=None, description="Link to redeem the reward at. You need to deliver this link to the recipient. ")
     __properties: ClassVar[List[str]] = ["method", "status", "link"]
 
-    @field_validator('method')
-    def method_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['EMAIL', 'LINK', 'PHONE']):
-            raise ValueError("must be one of enum values ('EMAIL', 'LINK', 'PHONE')")
-        return value
-
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['SCHEDULED', 'FAILED', 'SUCCEEDED', 'PENDING']):
-            raise ValueError("must be one of enum values ('SCHEDULED', 'FAILED', 'SUCCEEDED', 'PENDING')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/create_report200_response_report.py
+++ b/tremendous/models/create_report200_response_report.py
@@ -35,16 +35,6 @@ class CreateReport200ResponseReport(BaseModel):
     url: Optional[StrictStr] = Field(default=None, description="URL to download the report. Only returned when the report generation is complete and report is ready for download. URL is valid for 7 days from generation completion ")
     __properties: ClassVar[List[str]] = ["id", "status", "created_at", "expected_completion_at", "url"]
 
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['CREATED', 'PROCESSING', 'READY_FOR_DOWNLOAD', 'FAILED']):
-            raise ValueError("must be one of enum values ('CREATED', 'PROCESSING', 'READY_FOR_DOWNLOAD', 'FAILED')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/create_report_request.py
+++ b/tremendous/models/create_report_request.py
@@ -33,20 +33,6 @@ class CreateReportRequest(BaseModel):
     filters: Optional[CreateReportRequestFilters] = None
     __properties: ClassVar[List[str]] = ["report_type", "format", "filters"]
 
-    @field_validator('report_type')
-    def report_type_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['digital_rewards']):
-            raise ValueError("must be one of enum values ('digital_rewards')")
-        return value
-
-    @field_validator('format')
-    def format_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['csv']):
-            raise ValueError("must be one of enum values ('csv')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/create_report_request_filters_digital_rewards.py
+++ b/tremendous/models/create_report_request_filters_digital_rewards.py
@@ -40,37 +40,6 @@ class CreateReportRequestFiltersDigitalRewards(BaseModel):
     status: Optional[List[StrictStr]] = Field(default=None, description="Status for rewards returned in the report ")
     __properties: ClassVar[List[str]] = ["amount", "campaign_id", "created_at", "delivered_at", "delivery_method", "order_id", "order_status", "status"]
 
-    @field_validator('delivery_method')
-    def delivery_method_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['phone', 'email', 'link', 'mail', 'direct']):
-            raise ValueError("must be one of enum values ('phone', 'email', 'link', 'mail', 'direct')")
-        return value
-
-    @field_validator('order_status')
-    def order_status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['executed', 'canceled', 'failed', 'pending_approval']):
-            raise ValueError("must be one of enum values ('executed', 'canceled', 'failed', 'pending_approval')")
-        return value
-
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        for i in value:
-            if i not in set(['delivered', 'canceled', 'delivery_failed', 'pending_review']):
-                raise ValueError("each list item must be one of ('delivered', 'canceled', 'delivery_failed', 'pending_review')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/delivery_details.py
+++ b/tremendous/models/delivery_details.py
@@ -31,26 +31,6 @@ class DeliveryDetails(BaseModel):
     status: Optional[StrictStr] = Field(default=None, description="Current status of the delivery of the reward:  * `SCHEDULED` - Reward is scheduled for delivery and will be delivered soon. * `FAILED` - Delivery of reward failed (e.g. email bounced). * `SUCCEEDED` - Reward was successfully delivered (email or text message delivered or reward link active). * `PENDING` - Delivery is pending but not yet scheduled. ")
     __properties: ClassVar[List[str]] = ["method", "status"]
 
-    @field_validator('method')
-    def method_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['EMAIL', 'LINK', 'PHONE']):
-            raise ValueError("must be one of enum values ('EMAIL', 'LINK', 'PHONE')")
-        return value
-
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['SCHEDULED', 'FAILED', 'SUCCEEDED', 'PENDING']):
-            raise ValueError("must be one of enum values ('SCHEDULED', 'FAILED', 'SUCCEEDED', 'PENDING')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/delivery_details_with_link.py
+++ b/tremendous/models/delivery_details_with_link.py
@@ -32,20 +32,6 @@ class DeliveryDetailsWithLink(BaseModel):
     link: Optional[StrictStr] = Field(default=None, description="Link to redeem the reward at. You need to deliver this link to the recipient. ")
     __properties: ClassVar[List[str]] = ["method", "status", "link"]
 
-    @field_validator('method')
-    def method_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['EMAIL', 'LINK', 'PHONE']):
-            raise ValueError("must be one of enum values ('EMAIL', 'LINK', 'PHONE')")
-        return value
-
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['SCHEDULED', 'FAILED', 'SUCCEEDED', 'PENDING']):
-            raise ValueError("must be one of enum values ('SCHEDULED', 'FAILED', 'SUCCEEDED', 'PENDING')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/fraud_config_country.py
+++ b/tremendous/models/fraud_config_country.py
@@ -31,13 +31,6 @@ class FraudConfigCountry(BaseModel):
     countries: List[StrictStr] = Field(description="An array of country codes (ISO-3166 alpha-2 character code)")
     __properties: ClassVar[List[str]] = ["type", "countries"]
 
-    @field_validator('type')
-    def type_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['whitelist', 'blacklist']):
-            raise ValueError("must be one of enum values ('whitelist', 'blacklist')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/fraud_config_redeemed_rewards_amount.py
+++ b/tremendous/models/fraud_config_redeemed_rewards_amount.py
@@ -32,13 +32,6 @@ class FraudConfigRedeemedRewardsAmount(BaseModel):
     period: StrictStr = Field(description="The period, in days, to consider for the count. Use `all_time` to consider any redeemed rewards.")
     __properties: ClassVar[List[str]] = ["amount", "period"]
 
-    @field_validator('period')
-    def period_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['7', '30', '90', '120', '365', 'all_time']):
-            raise ValueError("must be one of enum values ('7', '30', '90', '120', '365', 'all_time')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/fraud_config_redeemed_rewards_count.py
+++ b/tremendous/models/fraud_config_redeemed_rewards_count.py
@@ -32,13 +32,6 @@ class FraudConfigRedeemedRewardsCount(BaseModel):
     period: StrictStr = Field(description="The period, in days, to consider for the count. Use `all_time` to consider any redeemed rewards.")
     __properties: ClassVar[List[str]] = ["amount", "period"]
 
-    @field_validator('period')
-    def period_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['7', '30', '90', '120', '365', 'all_time']):
-            raise ValueError("must be one of enum values ('7', '30', '90', '120', '365', 'all_time')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/fraud_review.py
+++ b/tremendous/models/fraud_review.py
@@ -45,47 +45,6 @@ class FraudReview(BaseModel):
     related_rewards: Optional[FraudReviewRelatedRewards] = None
     __properties: ClassVar[List[str]] = ["status", "reasons", "device_id", "redemption_method", "redeemed_at", "geo", "reward", "reviewed_by", "reviewed_at", "redemption_method_account_hash", "risk", "related_rewards"]
 
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['flagged', 'blocked', 'released']):
-            raise ValueError("must be one of enum values ('flagged', 'blocked', 'released')")
-        return value
-
-    @field_validator('reasons')
-    def reasons_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        for i in value:
-            if i not in set(['Disallowed IP', 'Disallowed email', 'Disallowed country', 'Over reward amount limit', 'Over reward count limit', 'VPN detected', 'Apple Private Relay', 'Device related to multiple emails', 'Device or account related to multiple emails', 'IP on a Tremendous fraud list', 'Bank account on a Tremendous fraud list', 'Fingerprint on a Tremendous fraud list', 'Email on a Tremendous fraud list', 'Phone on a Tremendous fraud list', 'Device on a Tremendous fraud list', 'IP related to a blocked reward', 'Device related to a blocked reward', 'Bank account related to a blocked reward', 'Fingerprint related to a blocked reward', 'Email related to a blocked reward', 'Phone related to a blocked reward', 'Allowed IP', 'Allowed email', 'Allowed country']):
-                raise ValueError("each list item must be one of ('Disallowed IP', 'Disallowed email', 'Disallowed country', 'Over reward amount limit', 'Over reward count limit', 'VPN detected', 'Apple Private Relay', 'Device related to multiple emails', 'Device or account related to multiple emails', 'IP on a Tremendous fraud list', 'Bank account on a Tremendous fraud list', 'Fingerprint on a Tremendous fraud list', 'Email on a Tremendous fraud list', 'Phone on a Tremendous fraud list', 'Device on a Tremendous fraud list', 'IP related to a blocked reward', 'Device related to a blocked reward', 'Bank account related to a blocked reward', 'Fingerprint related to a blocked reward', 'Email related to a blocked reward', 'Phone related to a blocked reward', 'Allowed IP', 'Allowed email', 'Allowed country')")
-        return value
-
-    @field_validator('redemption_method')
-    def redemption_method_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['bank transfer', 'charity', 'instant debit transfer', 'international bank transfer', 'merchant card', 'paypal', 'venmo', 'visa card']):
-            raise ValueError("must be one of enum values ('bank transfer', 'charity', 'instant debit transfer', 'international bank transfer', 'merchant card', 'paypal', 'venmo', 'visa card')")
-        return value
-
-    @field_validator('risk')
-    def risk_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['high', 'medium', 'low']):
-            raise ValueError("must be one of enum values ('high', 'medium', 'low')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/fraud_review_base.py
+++ b/tremendous/models/fraud_review_base.py
@@ -42,37 +42,6 @@ class FraudReviewBase(BaseModel):
     redemption_method_account_hash: Optional[StrictStr] = Field(default=None, description="A hash of the destination account for redemption methods that require providing 3rd party account details (e.g., PayPal, Venmo, ACH/CashApp, international bank transfers, etc.). The hash is globally unique by redemption method + account combination. This field is omitted for redemption methods that don't have a destination account (e.g., merchant cards, charities, etc.). ")
     __properties: ClassVar[List[str]] = ["status", "reasons", "device_id", "redemption_method", "redeemed_at", "geo", "reward", "reviewed_by", "reviewed_at", "redemption_method_account_hash"]
 
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['flagged', 'blocked', 'released']):
-            raise ValueError("must be one of enum values ('flagged', 'blocked', 'released')")
-        return value
-
-    @field_validator('reasons')
-    def reasons_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        for i in value:
-            if i not in set(['Disallowed IP', 'Disallowed email', 'Disallowed country', 'Over reward amount limit', 'Over reward count limit', 'VPN detected', 'Apple Private Relay', 'Device related to multiple emails', 'Device or account related to multiple emails', 'IP on a Tremendous fraud list', 'Bank account on a Tremendous fraud list', 'Fingerprint on a Tremendous fraud list', 'Email on a Tremendous fraud list', 'Phone on a Tremendous fraud list', 'Device on a Tremendous fraud list', 'IP related to a blocked reward', 'Device related to a blocked reward', 'Bank account related to a blocked reward', 'Fingerprint related to a blocked reward', 'Email related to a blocked reward', 'Phone related to a blocked reward', 'Allowed IP', 'Allowed email', 'Allowed country']):
-                raise ValueError("each list item must be one of ('Disallowed IP', 'Disallowed email', 'Disallowed country', 'Over reward amount limit', 'Over reward count limit', 'VPN detected', 'Apple Private Relay', 'Device related to multiple emails', 'Device or account related to multiple emails', 'IP on a Tremendous fraud list', 'Bank account on a Tremendous fraud list', 'Fingerprint on a Tremendous fraud list', 'Email on a Tremendous fraud list', 'Phone on a Tremendous fraud list', 'Device on a Tremendous fraud list', 'IP related to a blocked reward', 'Device related to a blocked reward', 'Bank account related to a blocked reward', 'Fingerprint related to a blocked reward', 'Email related to a blocked reward', 'Phone related to a blocked reward', 'Allowed IP', 'Allowed email', 'Allowed country')")
-        return value
-
-    @field_validator('redemption_method')
-    def redemption_method_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['bank transfer', 'charity', 'instant debit transfer', 'international bank transfer', 'merchant card', 'paypal', 'venmo', 'visa card']):
-            raise ValueError("must be one of enum values ('bank transfer', 'charity', 'instant debit transfer', 'international bank transfer', 'merchant card', 'paypal', 'venmo', 'visa card')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/fraud_review_list_item.py
+++ b/tremendous/models/fraud_review_list_item.py
@@ -42,37 +42,6 @@ class FraudReviewListItem(BaseModel):
     redemption_method_account_hash: Optional[StrictStr] = Field(default=None, description="A hash of the destination account for redemption methods that require providing 3rd party account details (e.g., PayPal, Venmo, ACH/CashApp, international bank transfers, etc.). The hash is globally unique by redemption method + account combination. This field is omitted for redemption methods that don't have a destination account (e.g., merchant cards, charities, etc.). ")
     __properties: ClassVar[List[str]] = ["status", "reasons", "device_id", "redemption_method", "redeemed_at", "geo", "reward", "reviewed_by", "reviewed_at", "redemption_method_account_hash"]
 
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['flagged', 'blocked', 'released']):
-            raise ValueError("must be one of enum values ('flagged', 'blocked', 'released')")
-        return value
-
-    @field_validator('reasons')
-    def reasons_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        for i in value:
-            if i not in set(['Disallowed IP', 'Disallowed email', 'Disallowed country', 'Over reward amount limit', 'Over reward count limit', 'VPN detected', 'Apple Private Relay', 'Device related to multiple emails', 'Device or account related to multiple emails', 'IP on a Tremendous fraud list', 'Bank account on a Tremendous fraud list', 'Fingerprint on a Tremendous fraud list', 'Email on a Tremendous fraud list', 'Phone on a Tremendous fraud list', 'Device on a Tremendous fraud list', 'IP related to a blocked reward', 'Device related to a blocked reward', 'Bank account related to a blocked reward', 'Fingerprint related to a blocked reward', 'Email related to a blocked reward', 'Phone related to a blocked reward', 'Allowed IP', 'Allowed email', 'Allowed country']):
-                raise ValueError("each list item must be one of ('Disallowed IP', 'Disallowed email', 'Disallowed country', 'Over reward amount limit', 'Over reward count limit', 'VPN detected', 'Apple Private Relay', 'Device related to multiple emails', 'Device or account related to multiple emails', 'IP on a Tremendous fraud list', 'Bank account on a Tremendous fraud list', 'Fingerprint on a Tremendous fraud list', 'Email on a Tremendous fraud list', 'Phone on a Tremendous fraud list', 'Device on a Tremendous fraud list', 'IP related to a blocked reward', 'Device related to a blocked reward', 'Bank account related to a blocked reward', 'Fingerprint related to a blocked reward', 'Email related to a blocked reward', 'Phone related to a blocked reward', 'Allowed IP', 'Allowed email', 'Allowed country')")
-        return value
-
-    @field_validator('redemption_method')
-    def redemption_method_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['bank transfer', 'charity', 'instant debit transfer', 'international bank transfer', 'merchant card', 'paypal', 'venmo', 'visa card']):
-            raise ValueError("must be one of enum values ('bank transfer', 'charity', 'instant debit transfer', 'international bank transfer', 'merchant card', 'paypal', 'venmo', 'visa card')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/fraud_rules_list_item.py
+++ b/tremendous/models/fraud_rules_list_item.py
@@ -31,16 +31,6 @@ class FraudRulesListItem(BaseModel):
     config: Optional[Dict[str, Any]] = Field(default=None, description="The configuration associated with the rule. The properties allowed depend on the type of rule. This property is only present for rules that require configuration. ")
     __properties: ClassVar[List[str]] = ["rule_type", "config"]
 
-    @field_validator('rule_type')
-    def rule_type_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['review_country', 'review_ip', 'review_email', 'review_redeemed_rewards_count', 'review_redeemed_rewards_amount', 'review_multiple_emails', 'review_vpn', 'review_tremendous_flag_list', 'review_previously_blocked_recipients', 'allow_ip', 'allow_email']):
-            raise ValueError("must be one of enum values ('review_country', 'review_ip', 'review_email', 'review_redeemed_rewards_count', 'review_redeemed_rewards_amount', 'review_multiple_emails', 'review_vpn', 'review_tremendous_flag_list', 'review_previously_blocked_recipients', 'allow_ip', 'allow_email')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/funding_source.py
+++ b/tremendous/models/funding_source.py
@@ -44,44 +44,6 @@ class FundingSource(BaseModel):
             raise ValueError(r"must validate the regular expression /[A-Z0-9]{4,20}/")
         return value
 
-    @field_validator('method')
-    def method_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['balance', 'bank_account', 'credit_card', 'invoice']):
-            raise ValueError("must be one of enum values ('balance', 'bank_account', 'credit_card', 'invoice')")
-        return value
-
-    @field_validator('usage_permissions')
-    def usage_permissions_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        for i in value:
-            if i not in set(['api_orders', 'dashboard_orders', 'balance_funding']):
-                raise ValueError("each list item must be one of ('api_orders', 'dashboard_orders', 'balance_funding')")
-        return value
-
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['active', 'deleted', 'failed']):
-            raise ValueError("must be one of enum values ('active', 'deleted', 'failed')")
-        return value
-
-    @field_validator('type')
-    def type_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['COMMERCIAL', 'PRO_FORMA', 'PREFUNDING_ONLY']):
-            raise ValueError("must be one of enum values ('COMMERCIAL', 'PRO_FORMA', 'PREFUNDING_ONLY')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/get_fraud_review200_response_fraud_review.py
+++ b/tremendous/models/get_fraud_review200_response_fraud_review.py
@@ -45,47 +45,6 @@ class GetFraudReview200ResponseFraudReview(BaseModel):
     related_rewards: Optional[GetFraudReview200ResponseFraudReviewRelatedRewards] = None
     __properties: ClassVar[List[str]] = ["status", "reasons", "device_id", "redemption_method", "redeemed_at", "geo", "reward", "reviewed_by", "reviewed_at", "redemption_method_account_hash", "risk", "related_rewards"]
 
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['flagged', 'blocked', 'released']):
-            raise ValueError("must be one of enum values ('flagged', 'blocked', 'released')")
-        return value
-
-    @field_validator('reasons')
-    def reasons_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        for i in value:
-            if i not in set(['Disallowed IP', 'Disallowed email', 'Disallowed country', 'Over reward amount limit', 'Over reward count limit', 'VPN detected', 'Apple Private Relay', 'Device related to multiple emails', 'Device or account related to multiple emails', 'IP on a Tremendous fraud list', 'Bank account on a Tremendous fraud list', 'Fingerprint on a Tremendous fraud list', 'Email on a Tremendous fraud list', 'Phone on a Tremendous fraud list', 'Device on a Tremendous fraud list', 'IP related to a blocked reward', 'Device related to a blocked reward', 'Bank account related to a blocked reward', 'Fingerprint related to a blocked reward', 'Email related to a blocked reward', 'Phone related to a blocked reward', 'Allowed IP', 'Allowed email', 'Allowed country']):
-                raise ValueError("each list item must be one of ('Disallowed IP', 'Disallowed email', 'Disallowed country', 'Over reward amount limit', 'Over reward count limit', 'VPN detected', 'Apple Private Relay', 'Device related to multiple emails', 'Device or account related to multiple emails', 'IP on a Tremendous fraud list', 'Bank account on a Tremendous fraud list', 'Fingerprint on a Tremendous fraud list', 'Email on a Tremendous fraud list', 'Phone on a Tremendous fraud list', 'Device on a Tremendous fraud list', 'IP related to a blocked reward', 'Device related to a blocked reward', 'Bank account related to a blocked reward', 'Fingerprint related to a blocked reward', 'Email related to a blocked reward', 'Phone related to a blocked reward', 'Allowed IP', 'Allowed email', 'Allowed country')")
-        return value
-
-    @field_validator('redemption_method')
-    def redemption_method_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['bank transfer', 'charity', 'instant debit transfer', 'international bank transfer', 'merchant card', 'paypal', 'venmo', 'visa card']):
-            raise ValueError("must be one of enum values ('bank transfer', 'charity', 'instant debit transfer', 'international bank transfer', 'merchant card', 'paypal', 'venmo', 'visa card')")
-        return value
-
-    @field_validator('risk')
-    def risk_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['high', 'medium', 'low']):
-            raise ValueError("must be one of enum values ('high', 'medium', 'low')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/get_member200_response_member.py
+++ b/tremendous/models/get_member200_response_member.py
@@ -45,13 +45,6 @@ class GetMember200ResponseMember(BaseModel):
             raise ValueError(r"must validate the regular expression /[A-Z0-9]{4,20}/")
         return value
 
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['REGISTERED', 'INVITED']):
-            raise ValueError("must be one of enum values ('REGISTERED', 'INVITED')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/get_member200_response_member_events_inner.py
+++ b/tremendous/models/get_member200_response_member_events_inner.py
@@ -32,16 +32,6 @@ class GetMember200ResponseMemberEventsInner(BaseModel):
     date_utc: Optional[datetime] = Field(default=None, description="Timestamp when the event happened")
     __properties: ClassVar[List[str]] = ["type", "date_utc"]
 
-    @field_validator('type')
-    def type_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['created', 'last_login']):
-            raise ValueError("must be one of enum values ('created', 'last_login')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/invoice.py
+++ b/tremendous/models/invoice.py
@@ -42,33 +42,6 @@ class Invoice(BaseModel):
     paid_at: Optional[datetime] = Field(description="Timestamp of when the invoice has been paid. ")
     __properties: ClassVar[List[str]] = ["id", "po_number", "amount", "currency_code", "currency", "international", "status", "orders", "rewards", "created_at", "paid_at"]
 
-    @field_validator('currency_code')
-    def currency_code_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['USD', 'EUR', 'GBP']):
-            raise ValueError("must be one of enum values ('USD', 'EUR', 'GBP')")
-        return value
-
-    @field_validator('currency')
-    def currency_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['USD', 'EUR', 'GBP']):
-            raise ValueError("must be one of enum values ('USD', 'EUR', 'GBP')")
-        return value
-
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['DELETED', 'PAID', 'OPEN', 'MARKED_AS_PAID']):
-            raise ValueError("must be one of enum values ('DELETED', 'PAID', 'OPEN', 'MARKED_AS_PAID')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/list_campaigns200_response_campaigns_inner.py
+++ b/tremendous/models/list_campaigns200_response_campaigns_inner.py
@@ -51,16 +51,6 @@ class ListCampaigns200ResponseCampaignsInner(BaseModel):
             raise ValueError(r"must validate the regular expression /[A-Z0-9]{4,20}/")
         return value
 
-    @field_validator('fee_charged_to')
-    def fee_charged_to_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['SENDER', 'RECIPIENT']):
-            raise ValueError("must be one of enum values ('SENDER', 'RECIPIENT')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/list_connected_organization_members200_response_connected_organization_members_inner_member.py
+++ b/tremendous/models/list_connected_organization_members200_response_connected_organization_members_inner_member.py
@@ -46,13 +46,6 @@ class ListConnectedOrganizationMembers200ResponseConnectedOrganizationMembersInn
             raise ValueError(r"must validate the regular expression /[A-Z0-9]{4,20}/")
         return value
 
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['REGISTERED', 'INVITED']):
-            raise ValueError("must be one of enum values ('REGISTERED', 'INVITED')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/list_connected_organizations200_response_connected_organizations_inner_organization.py
+++ b/tremendous/models/list_connected_organizations200_response_connected_organizations_inner_organization.py
@@ -47,16 +47,6 @@ class ListConnectedOrganizations200ResponseConnectedOrganizationsInnerOrganizati
             raise ValueError(r"must validate the regular expression /[A-Z0-9]{4,20}/")
         return value
 
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['PENDING', 'APPROVED', 'REJECTED']):
-            raise ValueError("must be one of enum values ('PENDING', 'APPROVED', 'REJECTED')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/list_fields200_response_fields_inner.py
+++ b/tremendous/models/list_fields200_response_fields_inner.py
@@ -47,16 +47,6 @@ class ListFields200ResponseFieldsInner(BaseModel):
             raise ValueError(r"must validate the regular expression /[A-Z0-9]{4,20}/")
         return value
 
-    @field_validator('data_type')
-    def data_type_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['Checkbox', 'Currency', 'Date', 'Dropdown', 'Email', 'List', 'Number', 'Phone', 'Text', 'TextArea']):
-            raise ValueError("must be one of enum values ('Checkbox', 'Currency', 'Date', 'Dropdown', 'Email', 'List', 'Number', 'Phone', 'Text', 'TextArea')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/list_fraud_reviews200_response_fraud_reviews_inner.py
+++ b/tremendous/models/list_fraud_reviews200_response_fraud_reviews_inner.py
@@ -42,37 +42,6 @@ class ListFraudReviews200ResponseFraudReviewsInner(BaseModel):
     redemption_method_account_hash: Optional[StrictStr] = Field(default=None, description="A hash of the destination account for redemption methods that require providing 3rd party account details (e.g., PayPal, Venmo, ACH/CashApp, international bank transfers, etc.). The hash is globally unique by redemption method + account combination. This field is omitted for redemption methods that don't have a destination account (e.g., merchant cards, charities, etc.). ")
     __properties: ClassVar[List[str]] = ["status", "reasons", "device_id", "redemption_method", "redeemed_at", "geo", "reward", "reviewed_by", "reviewed_at", "redemption_method_account_hash"]
 
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['flagged', 'blocked', 'released']):
-            raise ValueError("must be one of enum values ('flagged', 'blocked', 'released')")
-        return value
-
-    @field_validator('reasons')
-    def reasons_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        for i in value:
-            if i not in set(['Disallowed IP', 'Disallowed email', 'Disallowed country', 'Over reward amount limit', 'Over reward count limit', 'VPN detected', 'Apple Private Relay', 'Device related to multiple emails', 'Device or account related to multiple emails', 'IP on a Tremendous fraud list', 'Bank account on a Tremendous fraud list', 'Fingerprint on a Tremendous fraud list', 'Email on a Tremendous fraud list', 'Phone on a Tremendous fraud list', 'Device on a Tremendous fraud list', 'IP related to a blocked reward', 'Device related to a blocked reward', 'Bank account related to a blocked reward', 'Fingerprint related to a blocked reward', 'Email related to a blocked reward', 'Phone related to a blocked reward', 'Allowed IP', 'Allowed email', 'Allowed country']):
-                raise ValueError("each list item must be one of ('Disallowed IP', 'Disallowed email', 'Disallowed country', 'Over reward amount limit', 'Over reward count limit', 'VPN detected', 'Apple Private Relay', 'Device related to multiple emails', 'Device or account related to multiple emails', 'IP on a Tremendous fraud list', 'Bank account on a Tremendous fraud list', 'Fingerprint on a Tremendous fraud list', 'Email on a Tremendous fraud list', 'Phone on a Tremendous fraud list', 'Device on a Tremendous fraud list', 'IP related to a blocked reward', 'Device related to a blocked reward', 'Bank account related to a blocked reward', 'Fingerprint related to a blocked reward', 'Email related to a blocked reward', 'Phone related to a blocked reward', 'Allowed IP', 'Allowed email', 'Allowed country')")
-        return value
-
-    @field_validator('redemption_method')
-    def redemption_method_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['bank transfer', 'charity', 'instant debit transfer', 'international bank transfer', 'merchant card', 'paypal', 'venmo', 'visa card']):
-            raise ValueError("must be one of enum values ('bank transfer', 'charity', 'instant debit transfer', 'international bank transfer', 'merchant card', 'paypal', 'venmo', 'visa card')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/list_fraud_rules200_response_fraud_rules_inner.py
+++ b/tremendous/models/list_fraud_rules200_response_fraud_rules_inner.py
@@ -31,16 +31,6 @@ class ListFraudRules200ResponseFraudRulesInner(BaseModel):
     config: Optional[Dict[str, Any]] = Field(default=None, description="The configuration associated with the rule. The properties allowed depend on the type of rule. This property is only present for rules that require configuration. ")
     __properties: ClassVar[List[str]] = ["rule_type", "config"]
 
-    @field_validator('rule_type')
-    def rule_type_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['review_country', 'review_ip', 'review_email', 'review_redeemed_rewards_count', 'review_redeemed_rewards_amount', 'review_multiple_emails', 'review_vpn', 'review_tremendous_flag_list', 'review_previously_blocked_recipients', 'allow_ip', 'allow_email']):
-            raise ValueError("must be one of enum values ('review_country', 'review_ip', 'review_email', 'review_redeemed_rewards_count', 'review_redeemed_rewards_amount', 'review_multiple_emails', 'review_vpn', 'review_tremendous_flag_list', 'review_previously_blocked_recipients', 'allow_ip', 'allow_email')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/list_funding_sources200_response_funding_sources_inner.py
+++ b/tremendous/models/list_funding_sources200_response_funding_sources_inner.py
@@ -44,44 +44,6 @@ class ListFundingSources200ResponseFundingSourcesInner(BaseModel):
             raise ValueError(r"must validate the regular expression /[A-Z0-9]{4,20}/")
         return value
 
-    @field_validator('method')
-    def method_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['balance', 'bank_account', 'credit_card', 'invoice']):
-            raise ValueError("must be one of enum values ('balance', 'bank_account', 'credit_card', 'invoice')")
-        return value
-
-    @field_validator('usage_permissions')
-    def usage_permissions_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        for i in value:
-            if i not in set(['api_orders', 'dashboard_orders', 'balance_funding']):
-                raise ValueError("each list item must be one of ('api_orders', 'dashboard_orders', 'balance_funding')")
-        return value
-
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['active', 'deleted', 'failed']):
-            raise ValueError("must be one of enum values ('active', 'deleted', 'failed')")
-        return value
-
-    @field_validator('type')
-    def type_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['COMMERCIAL', 'PRO_FORMA', 'PREFUNDING_ONLY']):
-            raise ValueError("must be one of enum values ('COMMERCIAL', 'PRO_FORMA', 'PREFUNDING_ONLY')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/list_funding_sources200_response_funding_sources_inner_meta.py
+++ b/tremendous/models/list_funding_sources200_response_funding_sources_inner_meta.py
@@ -64,16 +64,6 @@ class ListFundingSources200ResponseFundingSourcesInnerMeta(BaseModel):
     failure_details: Optional[ListFundingSources200ResponseFundingSourcesInnerMetaFailureDetails] = None
     __properties: ClassVar[List[str]] = ["available_amount", "available_cents", "currency_code", "pending_amount", "pending_cents", "credit_limit_amount", "credit_limit_cents", "accountholder_name", "account_type", "bank_name", "account_number_mask", "account_routing_mask", "refundable", "network", "last4", "expired", "year", "month", "last_payment_failed_at", "invoice_type", "interval", "day_of_week", "net", "company_name", "address_1", "address_2", "city", "state", "zip", "phone", "emails", "failure_details"]
 
-    @field_validator('account_type')
-    def account_type_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['checking', 'savings']):
-            raise ValueError("must be one of enum values ('checking', 'savings')")
-        return value
-
     @field_validator('account_number_mask')
     def account_number_mask_validate_regular_expression(cls, value):
         """Validates the regular expression"""
@@ -92,16 +82,6 @@ class ListFundingSources200ResponseFundingSourcesInnerMeta(BaseModel):
 
         if not re.match(r"[0-9]{4}", value):
             raise ValueError(r"must validate the regular expression /[0-9]{4}/")
-        return value
-
-    @field_validator('network')
-    def network_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['MasterCard', 'Amex', 'JCB', 'Diner\'s Club', 'Visa', 'Discover', 'Laser', 'Elo', 'Maestro', 'Solo']):
-            raise ValueError("must be one of enum values ('MasterCard', 'Amex', 'JCB', 'Diner\'s Club', 'Visa', 'Discover', 'Laser', 'Elo', 'Maestro', 'Solo')")
         return value
 
     @field_validator('last4')

--- a/tremendous/models/list_invoices200_response_invoices_inner.py
+++ b/tremendous/models/list_invoices200_response_invoices_inner.py
@@ -42,33 +42,6 @@ class ListInvoices200ResponseInvoicesInner(BaseModel):
     paid_at: Optional[datetime] = Field(description="Timestamp of when the invoice has been paid. ")
     __properties: ClassVar[List[str]] = ["id", "po_number", "amount", "currency_code", "currency", "international", "status", "orders", "rewards", "created_at", "paid_at"]
 
-    @field_validator('currency_code')
-    def currency_code_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['USD', 'EUR', 'GBP']):
-            raise ValueError("must be one of enum values ('USD', 'EUR', 'GBP')")
-        return value
-
-    @field_validator('currency')
-    def currency_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['USD', 'EUR', 'GBP']):
-            raise ValueError("must be one of enum values ('USD', 'EUR', 'GBP')")
-        return value
-
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['DELETED', 'PAID', 'OPEN', 'MARKED_AS_PAID']):
-            raise ValueError("must be one of enum values ('DELETED', 'PAID', 'OPEN', 'MARKED_AS_PAID')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/list_members200_response_members_inner.py
+++ b/tremendous/models/list_members200_response_members_inner.py
@@ -46,13 +46,6 @@ class ListMembers200ResponseMembersInner(BaseModel):
             raise ValueError(r"must validate the regular expression /[A-Z0-9]{4,20}/")
         return value
 
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['REGISTERED', 'INVITED']):
-            raise ValueError("must be one of enum values ('REGISTERED', 'INVITED')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/list_orders200_response_orders_inner.py
+++ b/tremendous/models/list_orders200_response_orders_inner.py
@@ -59,23 +59,6 @@ class ListOrders200ResponseOrdersInner(BaseModel):
             raise ValueError(r"must validate the regular expression /[A-Z0-9]{4,20}/")
         return value
 
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT']):
-            raise ValueError("must be one of enum values ('CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT')")
-        return value
-
-    @field_validator('channel')
-    def channel_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO']):
-            raise ValueError("must be one of enum values ('UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/list_organizations200_response_organizations_inner.py
+++ b/tremendous/models/list_organizations200_response_organizations_inner.py
@@ -47,16 +47,6 @@ class ListOrganizations200ResponseOrganizationsInner(BaseModel):
             raise ValueError(r"must validate the regular expression /[A-Z0-9]{4,20}/")
         return value
 
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['PENDING', 'APPROVED', 'REJECTED']):
-            raise ValueError("must be one of enum values ('PENDING', 'APPROVED', 'REJECTED')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/list_products_response_products_inner.py
+++ b/tremendous/models/list_products_response_products_inner.py
@@ -53,31 +53,6 @@ class ListProductsResponseProductsInner(BaseModel):
             raise ValueError(r"must validate the regular expression /[A-Z0-9]{4,20}/")
         return value
 
-    @field_validator('category')
-    def category_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['ach', 'charity', 'instant_debit_transfer', 'merchant_card', 'paypal', 'venmo', 'visa_card', 'cash_app', 'international_bank', 'wallet']):
-            raise ValueError("must be one of enum values ('ach', 'charity', 'instant_debit_transfer', 'merchant_card', 'paypal', 'venmo', 'visa_card', 'cash_app', 'international_bank', 'wallet')")
-        return value
-
-    @field_validator('subcategory')
-    def subcategory_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['beauty_and_health', 'digital_financial_services', 'electronics', 'entertainment', 'fashion', 'food_and_drink', 'general_merchandise', 'grocery_and_supermarkets', 'home_and_living', 'mobility_and_fuel', 'sports_and_outdoor_gear', 'travel_and_hospitality']):
-            raise ValueError("must be one of enum values ('beauty_and_health', 'digital_financial_services', 'electronics', 'entertainment', 'fashion', 'food_and_drink', 'general_merchandise', 'grocery_and_supermarkets', 'home_and_living', 'mobility_and_fuel', 'sports_and_outdoor_gear', 'travel_and_hospitality')")
-        return value
-
-    @field_validator('currency_codes')
-    def currency_codes_validate_enum(cls, value):
-        """Validates the enum"""
-        for i in value:
-            if i not in set(['USD', 'CAD', 'EUR', 'AED', 'AFN', 'ALL', 'AMD', 'ARS', 'AUD', 'AZN', 'BAM', 'BDT', 'BHD', 'BIF', 'BND', 'BOB', 'BRL', 'BWP', 'BYN', 'BZD', 'CDF', 'CHF', 'CLP', 'CNY', 'COP', 'CRC', 'CVE', 'CZK', 'DJF', 'DKK', 'DOP', 'DZD', 'EGP', 'ERN', 'ETB', 'GBP', 'GEL', 'GHS', 'GNF', 'GTQ', 'HKD', 'HNL', 'HRK', 'HUF', 'IDR', 'ILS', 'INR', 'IQD', 'IRR', 'ISK', 'JMD', 'JOD', 'JPY', 'KES', 'KHR', 'KRW', 'KWD', 'KZT', 'LBP', 'LKR', 'MAD', 'MDL', 'MGA', 'MKD', 'MMK', 'MOP', 'MUR', 'MXN', 'MYR', 'MZN', 'NAD', 'NGN', 'NIO', 'NOK', 'NPR', 'NZD', 'OMR', 'PAB', 'PEN', 'PHP', 'PKR', 'PLN', 'PYG', 'QAR', 'RON', 'RSD', 'RUB', 'RWF', 'SAR', 'SDG', 'SEK', 'SGD', 'SOS', 'SYP', 'THB', 'TND', 'TOP', 'TRY', 'TTD', 'TWD', 'TZS', 'UAH', 'UGX', 'UYU', 'UZS', 'VEF', 'VND', 'XAF', 'XOF', 'YER', 'ZAR']):
-                raise ValueError("each list item must be one of ('USD', 'CAD', 'EUR', 'AED', 'AFN', 'ALL', 'AMD', 'ARS', 'AUD', 'AZN', 'BAM', 'BDT', 'BHD', 'BIF', 'BND', 'BOB', 'BRL', 'BWP', 'BYN', 'BZD', 'CDF', 'CHF', 'CLP', 'CNY', 'COP', 'CRC', 'CVE', 'CZK', 'DJF', 'DKK', 'DOP', 'DZD', 'EGP', 'ERN', 'ETB', 'GBP', 'GEL', 'GHS', 'GNF', 'GTQ', 'HKD', 'HNL', 'HRK', 'HUF', 'IDR', 'ILS', 'INR', 'IQD', 'IRR', 'ISK', 'JMD', 'JOD', 'JPY', 'KES', 'KHR', 'KRW', 'KWD', 'KZT', 'LBP', 'LKR', 'MAD', 'MDL', 'MGA', 'MKD', 'MMK', 'MOP', 'MUR', 'MXN', 'MYR', 'MZN', 'NAD', 'NGN', 'NIO', 'NOK', 'NPR', 'NZD', 'OMR', 'PAB', 'PEN', 'PHP', 'PKR', 'PLN', 'PYG', 'QAR', 'RON', 'RSD', 'RUB', 'RWF', 'SAR', 'SDG', 'SEK', 'SGD', 'SOS', 'SYP', 'THB', 'TND', 'TOP', 'TRY', 'TTD', 'TWD', 'TZS', 'UAH', 'UGX', 'UYU', 'UZS', 'VEF', 'VND', 'XAF', 'XOF', 'YER', 'ZAR')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/list_products_response_products_inner_images_inner.py
+++ b/tremendous/models/list_products_response_products_inner_images_inner.py
@@ -32,13 +32,6 @@ class ListProductsResponseProductsInnerImagesInner(BaseModel):
     content_type: Optional[StrictStr] = Field(default=None, description="The MIME content type of this image")
     __properties: ClassVar[List[str]] = ["src", "type", "content_type"]
 
-    @field_validator('type')
-    def type_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['card', 'logo']):
-            raise ValueError("must be one of enum values ('card', 'logo')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/list_rewards200_response_rewards_inner_delivery.py
+++ b/tremendous/models/list_rewards200_response_rewards_inner_delivery.py
@@ -31,26 +31,6 @@ class ListRewards200ResponseRewardsInnerDelivery(BaseModel):
     status: Optional[StrictStr] = Field(default=None, description="Current status of the delivery of the reward:  * `SCHEDULED` - Reward is scheduled for delivery and will be delivered soon. * `FAILED` - Delivery of reward failed (e.g. email bounced). * `SUCCEEDED` - Reward was successfully delivered (email or text message delivered or reward link active). * `PENDING` - Delivery is pending but not yet scheduled. ")
     __properties: ClassVar[List[str]] = ["method", "status"]
 
-    @field_validator('method')
-    def method_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['EMAIL', 'LINK', 'PHONE']):
-            raise ValueError("must be one of enum values ('EMAIL', 'LINK', 'PHONE')")
-        return value
-
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['SCHEDULED', 'FAILED', 'SUCCEEDED', 'PENDING']):
-            raise ValueError("must be one of enum values ('SCHEDULED', 'FAILED', 'SUCCEEDED', 'PENDING')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/list_rewards200_response_rewards_inner_value.py
+++ b/tremendous/models/list_rewards200_response_rewards_inner_value.py
@@ -31,16 +31,6 @@ class ListRewards200ResponseRewardsInnerValue(BaseModel):
     currency_code: Optional[StrictStr] = Field(default=None, description="Currency of the reward. Defaults to the organization's currency if not provided.")
     __properties: ClassVar[List[str]] = ["denomination", "currency_code"]
 
-    @field_validator('currency_code')
-    def currency_code_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['USD', 'CAD', 'EUR', 'AED', 'AFN', 'ALL', 'AMD', 'ARS', 'AUD', 'AZN', 'BAM', 'BDT', 'BHD', 'BIF', 'BND', 'BOB', 'BRL', 'BWP', 'BYN', 'BZD', 'CDF', 'CHF', 'CLP', 'CNY', 'COP', 'CRC', 'CVE', 'CZK', 'DJF', 'DKK', 'DOP', 'DZD', 'EGP', 'ERN', 'ETB', 'GBP', 'GEL', 'GHS', 'GNF', 'GTQ', 'HKD', 'HNL', 'HRK', 'HUF', 'IDR', 'ILS', 'INR', 'IQD', 'IRR', 'ISK', 'JMD', 'JOD', 'JPY', 'KES', 'KHR', 'KRW', 'KWD', 'KZT', 'LBP', 'LKR', 'MAD', 'MDL', 'MGA', 'MKD', 'MMK', 'MOP', 'MUR', 'MXN', 'MYR', 'MZN', 'NAD', 'NGN', 'NIO', 'NOK', 'NPR', 'NZD', 'OMR', 'PAB', 'PEN', 'PHP', 'PKR', 'PLN', 'PYG', 'QAR', 'RON', 'RSD', 'RUB', 'RWF', 'SAR', 'SDG', 'SEK', 'SGD', 'SOS', 'SYP', 'THB', 'TND', 'TOP', 'TRY', 'TTD', 'TWD', 'TZS', 'UAH', 'UGX', 'UYU', 'UZS', 'VEF', 'VND', 'XAF', 'XOF', 'YER', 'ZAR']):
-            raise ValueError("must be one of enum values ('USD', 'CAD', 'EUR', 'AED', 'AFN', 'ALL', 'AMD', 'ARS', 'AUD', 'AZN', 'BAM', 'BDT', 'BHD', 'BIF', 'BND', 'BOB', 'BRL', 'BWP', 'BYN', 'BZD', 'CDF', 'CHF', 'CLP', 'CNY', 'COP', 'CRC', 'CVE', 'CZK', 'DJF', 'DKK', 'DOP', 'DZD', 'EGP', 'ERN', 'ETB', 'GBP', 'GEL', 'GHS', 'GNF', 'GTQ', 'HKD', 'HNL', 'HRK', 'HUF', 'IDR', 'ILS', 'INR', 'IQD', 'IRR', 'ISK', 'JMD', 'JOD', 'JPY', 'KES', 'KHR', 'KRW', 'KWD', 'KZT', 'LBP', 'LKR', 'MAD', 'MDL', 'MGA', 'MKD', 'MMK', 'MOP', 'MUR', 'MXN', 'MYR', 'MZN', 'NAD', 'NGN', 'NIO', 'NOK', 'NPR', 'NZD', 'OMR', 'PAB', 'PEN', 'PHP', 'PKR', 'PLN', 'PYG', 'QAR', 'RON', 'RSD', 'RUB', 'RWF', 'SAR', 'SDG', 'SEK', 'SGD', 'SOS', 'SYP', 'THB', 'TND', 'TOP', 'TRY', 'TTD', 'TWD', 'TZS', 'UAH', 'UGX', 'UYU', 'UZS', 'VEF', 'VND', 'XAF', 'XOF', 'YER', 'ZAR')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/member.py
+++ b/tremendous/models/member.py
@@ -46,13 +46,6 @@ class Member(BaseModel):
             raise ValueError(r"must validate the regular expression /[A-Z0-9]{4,20}/")
         return value
 
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['REGISTERED', 'INVITED']):
-            raise ValueError("must be one of enum values ('REGISTERED', 'INVITED')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/member_base.py
+++ b/tremendous/models/member_base.py
@@ -43,13 +43,6 @@ class MemberBase(BaseModel):
             raise ValueError(r"must validate the regular expression /[A-Z0-9]{4,20}/")
         return value
 
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['REGISTERED', 'INVITED']):
-            raise ValueError("must be one of enum values ('REGISTERED', 'INVITED')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/member_with_events.py
+++ b/tremendous/models/member_with_events.py
@@ -45,13 +45,6 @@ class MemberWithEvents(BaseModel):
             raise ValueError(r"must validate the regular expression /[A-Z0-9]{4,20}/")
         return value
 
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['REGISTERED', 'INVITED']):
-            raise ValueError("must be one of enum values ('REGISTERED', 'INVITED')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/member_without_events.py
+++ b/tremendous/models/member_without_events.py
@@ -46,13 +46,6 @@ class MemberWithoutEvents(BaseModel):
             raise ValueError(r"must validate the regular expression /[A-Z0-9]{4,20}/")
         return value
 
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['REGISTERED', 'INVITED']):
-            raise ValueError("must be one of enum values ('REGISTERED', 'INVITED')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/model_field.py
+++ b/tremendous/models/model_field.py
@@ -47,16 +47,6 @@ class ModelField(BaseModel):
             raise ValueError(r"must validate the regular expression /[A-Z0-9]{4,20}/")
         return value
 
-    @field_validator('data_type')
-    def data_type_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['Checkbox', 'Currency', 'Date', 'Dropdown', 'Email', 'List', 'Number', 'Phone', 'Text', 'TextArea']):
-            raise ValueError("must be one of enum values ('Checkbox', 'Currency', 'Date', 'Dropdown', 'Email', 'List', 'Number', 'Phone', 'Text', 'TextArea')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/order.py
+++ b/tremendous/models/order.py
@@ -59,23 +59,6 @@ class Order(BaseModel):
             raise ValueError(r"must validate the regular expression /[A-Z0-9]{4,20}/")
         return value
 
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT']):
-            raise ValueError("must be one of enum values ('CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT')")
-        return value
-
-    @field_validator('channel')
-    def channel_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO']):
-            raise ValueError("must be one of enum values ('UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/order_base.py
+++ b/tremendous/models/order_base.py
@@ -57,23 +57,6 @@ class OrderBase(BaseModel):
             raise ValueError(r"must validate the regular expression /[A-Z0-9]{4,20}/")
         return value
 
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT']):
-            raise ValueError("must be one of enum values ('CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT')")
-        return value
-
-    @field_validator('channel')
-    def channel_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO']):
-            raise ValueError("must be one of enum values ('UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/order_with_link.py
+++ b/tremendous/models/order_with_link.py
@@ -59,23 +59,6 @@ class OrderWithLink(BaseModel):
             raise ValueError(r"must validate the regular expression /[A-Z0-9]{4,20}/")
         return value
 
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT']):
-            raise ValueError("must be one of enum values ('CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT')")
-        return value
-
-    @field_validator('channel')
-    def channel_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO']):
-            raise ValueError("must be one of enum values ('UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/order_without_link.py
+++ b/tremendous/models/order_without_link.py
@@ -59,23 +59,6 @@ class OrderWithoutLink(BaseModel):
             raise ValueError(r"must validate the regular expression /[A-Z0-9]{4,20}/")
         return value
 
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT']):
-            raise ValueError("must be one of enum values ('CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT')")
-        return value
-
-    @field_validator('channel')
-    def channel_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO']):
-            raise ValueError("must be one of enum values ('UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/organization.py
+++ b/tremendous/models/organization.py
@@ -47,16 +47,6 @@ class Organization(BaseModel):
             raise ValueError(r"must validate the regular expression /[A-Z0-9]{4,20}/")
         return value
 
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['PENDING', 'APPROVED', 'REJECTED']):
-            raise ValueError("must be one of enum values ('PENDING', 'APPROVED', 'REJECTED')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/payout.py
+++ b/tremendous/models/payout.py
@@ -48,16 +48,6 @@ class Payout(BaseModel):
             raise ValueError(r"must validate the regular expression /[A-Z0-9]{4,20}/")
         return value
 
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['UNEXECUTED', 'COMPLETED', 'FAILED', 'CANCELED', 'ORGANIZATION_REVIEW', 'ADMIN_HELD']):
-            raise ValueError("must be one of enum values ('UNEXECUTED', 'COMPLETED', 'FAILED', 'CANCELED', 'ORGANIZATION_REVIEW', 'ADMIN_HELD')")
-        return value
-
     @field_validator('product_id')
     def product_id_validate_regular_expression(cls, value):
         """Validates the regular expression"""

--- a/tremendous/models/product.py
+++ b/tremendous/models/product.py
@@ -53,31 +53,6 @@ class Product(BaseModel):
             raise ValueError(r"must validate the regular expression /[A-Z0-9]{4,20}/")
         return value
 
-    @field_validator('category')
-    def category_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['ach', 'charity', 'instant_debit_transfer', 'merchant_card', 'paypal', 'venmo', 'visa_card', 'cash_app', 'international_bank', 'wallet']):
-            raise ValueError("must be one of enum values ('ach', 'charity', 'instant_debit_transfer', 'merchant_card', 'paypal', 'venmo', 'visa_card', 'cash_app', 'international_bank', 'wallet')")
-        return value
-
-    @field_validator('subcategory')
-    def subcategory_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['beauty_and_health', 'digital_financial_services', 'electronics', 'entertainment', 'fashion', 'food_and_drink', 'general_merchandise', 'grocery_and_supermarkets', 'home_and_living', 'mobility_and_fuel', 'sports_and_outdoor_gear', 'travel_and_hospitality']):
-            raise ValueError("must be one of enum values ('beauty_and_health', 'digital_financial_services', 'electronics', 'entertainment', 'fashion', 'food_and_drink', 'general_merchandise', 'grocery_and_supermarkets', 'home_and_living', 'mobility_and_fuel', 'sports_and_outdoor_gear', 'travel_and_hospitality')")
-        return value
-
-    @field_validator('currency_codes')
-    def currency_codes_validate_enum(cls, value):
-        """Validates the enum"""
-        for i in value:
-            if i not in set(['USD', 'CAD', 'EUR', 'AED', 'AFN', 'ALL', 'AMD', 'ARS', 'AUD', 'AZN', 'BAM', 'BDT', 'BHD', 'BIF', 'BND', 'BOB', 'BRL', 'BWP', 'BYN', 'BZD', 'CDF', 'CHF', 'CLP', 'CNY', 'COP', 'CRC', 'CVE', 'CZK', 'DJF', 'DKK', 'DOP', 'DZD', 'EGP', 'ERN', 'ETB', 'GBP', 'GEL', 'GHS', 'GNF', 'GTQ', 'HKD', 'HNL', 'HRK', 'HUF', 'IDR', 'ILS', 'INR', 'IQD', 'IRR', 'ISK', 'JMD', 'JOD', 'JPY', 'KES', 'KHR', 'KRW', 'KWD', 'KZT', 'LBP', 'LKR', 'MAD', 'MDL', 'MGA', 'MKD', 'MMK', 'MOP', 'MUR', 'MXN', 'MYR', 'MZN', 'NAD', 'NGN', 'NIO', 'NOK', 'NPR', 'NZD', 'OMR', 'PAB', 'PEN', 'PHP', 'PKR', 'PLN', 'PYG', 'QAR', 'RON', 'RSD', 'RUB', 'RWF', 'SAR', 'SDG', 'SEK', 'SGD', 'SOS', 'SYP', 'THB', 'TND', 'TOP', 'TRY', 'TTD', 'TWD', 'TZS', 'UAH', 'UGX', 'UYU', 'UZS', 'VEF', 'VND', 'XAF', 'XOF', 'YER', 'ZAR']):
-                raise ValueError("each list item must be one of ('USD', 'CAD', 'EUR', 'AED', 'AFN', 'ALL', 'AMD', 'ARS', 'AUD', 'AZN', 'BAM', 'BDT', 'BHD', 'BIF', 'BND', 'BOB', 'BRL', 'BWP', 'BYN', 'BZD', 'CDF', 'CHF', 'CLP', 'CNY', 'COP', 'CRC', 'CVE', 'CZK', 'DJF', 'DKK', 'DOP', 'DZD', 'EGP', 'ERN', 'ETB', 'GBP', 'GEL', 'GHS', 'GNF', 'GTQ', 'HKD', 'HNL', 'HRK', 'HUF', 'IDR', 'ILS', 'INR', 'IQD', 'IRR', 'ISK', 'JMD', 'JOD', 'JPY', 'KES', 'KHR', 'KRW', 'KWD', 'KZT', 'LBP', 'LKR', 'MAD', 'MDL', 'MGA', 'MKD', 'MMK', 'MOP', 'MUR', 'MXN', 'MYR', 'MZN', 'NAD', 'NGN', 'NIO', 'NOK', 'NPR', 'NZD', 'OMR', 'PAB', 'PEN', 'PHP', 'PKR', 'PLN', 'PYG', 'QAR', 'RON', 'RSD', 'RUB', 'RWF', 'SAR', 'SDG', 'SEK', 'SGD', 'SOS', 'SYP', 'THB', 'TND', 'TOP', 'TRY', 'TTD', 'TWD', 'TZS', 'UAH', 'UGX', 'UYU', 'UZS', 'VEF', 'VND', 'XAF', 'XOF', 'YER', 'ZAR')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/report.py
+++ b/tremendous/models/report.py
@@ -35,16 +35,6 @@ class Report(BaseModel):
     url: Optional[StrictStr] = Field(default=None, description="URL to download the report. Only returned when the report generation is complete and report is ready for download. URL is valid for 7 days from generation completion ")
     __properties: ClassVar[List[str]] = ["id", "status", "created_at", "expected_completion_at", "url"]
 
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['CREATED', 'PROCESSING', 'READY_FOR_DOWNLOAD', 'FAILED']):
-            raise ValueError("must be one of enum values ('CREATED', 'PROCESSING', 'READY_FOR_DOWNLOAD', 'FAILED')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/review_country.py
+++ b/tremendous/models/review_country.py
@@ -31,13 +31,6 @@ class ReviewCountry(BaseModel):
     countries: List[StrictStr] = Field(description="An array of country codes (ISO-3166 alpha-2 character code)")
     __properties: ClassVar[List[str]] = ["type", "countries"]
 
-    @field_validator('type')
-    def type_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['whitelist', 'blacklist']):
-            raise ValueError("must be one of enum values ('whitelist', 'blacklist')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/review_redeemed_rewards_amount.py
+++ b/tremendous/models/review_redeemed_rewards_amount.py
@@ -32,13 +32,6 @@ class ReviewRedeemedRewardsAmount(BaseModel):
     period: StrictStr = Field(description="The period, in days, to consider for the count. Use `all_time` to consider any redeemed rewards.")
     __properties: ClassVar[List[str]] = ["amount", "period"]
 
-    @field_validator('period')
-    def period_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['7', '30', '90', '120', '365', 'all_time']):
-            raise ValueError("must be one of enum values ('7', '30', '90', '120', '365', 'all_time')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/review_redeemed_rewards_count.py
+++ b/tremendous/models/review_redeemed_rewards_count.py
@@ -32,13 +32,6 @@ class ReviewRedeemedRewardsCount(BaseModel):
     period: StrictStr = Field(description="The period, in days, to consider for the count. Use `all_time` to consider any redeemed rewards.")
     __properties: ClassVar[List[str]] = ["amount", "period"]
 
-    @field_validator('period')
-    def period_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['7', '30', '90', '120', '365', 'all_time']):
-            raise ValueError("must be one of enum values ('7', '30', '90', '120', '365', 'all_time')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/reward_value.py
+++ b/tremendous/models/reward_value.py
@@ -31,16 +31,6 @@ class RewardValue(BaseModel):
     currency_code: Optional[StrictStr] = Field(default=None, description="Currency of the reward. Defaults to the organization's currency if not provided.")
     __properties: ClassVar[List[str]] = ["denomination", "currency_code"]
 
-    @field_validator('currency_code')
-    def currency_code_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['USD', 'CAD', 'EUR', 'AED', 'AFN', 'ALL', 'AMD', 'ARS', 'AUD', 'AZN', 'BAM', 'BDT', 'BHD', 'BIF', 'BND', 'BOB', 'BRL', 'BWP', 'BYN', 'BZD', 'CDF', 'CHF', 'CLP', 'CNY', 'COP', 'CRC', 'CVE', 'CZK', 'DJF', 'DKK', 'DOP', 'DZD', 'EGP', 'ERN', 'ETB', 'GBP', 'GEL', 'GHS', 'GNF', 'GTQ', 'HKD', 'HNL', 'HRK', 'HUF', 'IDR', 'ILS', 'INR', 'IQD', 'IRR', 'ISK', 'JMD', 'JOD', 'JPY', 'KES', 'KHR', 'KRW', 'KWD', 'KZT', 'LBP', 'LKR', 'MAD', 'MDL', 'MGA', 'MKD', 'MMK', 'MOP', 'MUR', 'MXN', 'MYR', 'MZN', 'NAD', 'NGN', 'NIO', 'NOK', 'NPR', 'NZD', 'OMR', 'PAB', 'PEN', 'PHP', 'PKR', 'PLN', 'PYG', 'QAR', 'RON', 'RSD', 'RUB', 'RWF', 'SAR', 'SDG', 'SEK', 'SGD', 'SOS', 'SYP', 'THB', 'TND', 'TOP', 'TRY', 'TTD', 'TWD', 'TZS', 'UAH', 'UGX', 'UYU', 'UZS', 'VEF', 'VND', 'XAF', 'XOF', 'YER', 'ZAR']):
-            raise ValueError("must be one of enum values ('USD', 'CAD', 'EUR', 'AED', 'AFN', 'ALL', 'AMD', 'ARS', 'AUD', 'AZN', 'BAM', 'BDT', 'BHD', 'BIF', 'BND', 'BOB', 'BRL', 'BWP', 'BYN', 'BZD', 'CDF', 'CHF', 'CLP', 'CNY', 'COP', 'CRC', 'CVE', 'CZK', 'DJF', 'DKK', 'DOP', 'DZD', 'EGP', 'ERN', 'ETB', 'GBP', 'GEL', 'GHS', 'GNF', 'GTQ', 'HKD', 'HNL', 'HRK', 'HUF', 'IDR', 'ILS', 'INR', 'IQD', 'IRR', 'ISK', 'JMD', 'JOD', 'JPY', 'KES', 'KHR', 'KRW', 'KWD', 'KZT', 'LBP', 'LKR', 'MAD', 'MDL', 'MGA', 'MKD', 'MMK', 'MOP', 'MUR', 'MXN', 'MYR', 'MZN', 'NAD', 'NGN', 'NIO', 'NOK', 'NPR', 'NZD', 'OMR', 'PAB', 'PEN', 'PHP', 'PKR', 'PLN', 'PYG', 'QAR', 'RON', 'RSD', 'RUB', 'RWF', 'SAR', 'SDG', 'SEK', 'SGD', 'SOS', 'SYP', 'THB', 'TND', 'TOP', 'TRY', 'TTD', 'TWD', 'TZS', 'UAH', 'UGX', 'UYU', 'UZS', 'VEF', 'VND', 'XAF', 'XOF', 'YER', 'ZAR')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/reward_with_link_delivery.py
+++ b/tremendous/models/reward_with_link_delivery.py
@@ -32,20 +32,6 @@ class RewardWithLinkDelivery(BaseModel):
     link: Optional[StrictStr] = Field(default=None, description="Link to redeem the reward at. You need to deliver this link to the recipient. ")
     __properties: ClassVar[List[str]] = ["method", "status", "link"]
 
-    @field_validator('method')
-    def method_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['EMAIL', 'LINK', 'PHONE']):
-            raise ValueError("must be one of enum values ('EMAIL', 'LINK', 'PHONE')")
-        return value
-
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['SCHEDULED', 'FAILED', 'SUCCEEDED', 'PENDING']):
-            raise ValueError("must be one of enum values ('SCHEDULED', 'FAILED', 'SUCCEEDED', 'PENDING')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/reward_without_link_delivery.py
+++ b/tremendous/models/reward_without_link_delivery.py
@@ -31,26 +31,6 @@ class RewardWithoutLinkDelivery(BaseModel):
     status: Optional[StrictStr] = Field(default=None, description="Current status of the delivery of the reward:  * `SCHEDULED` - Reward is scheduled for delivery and will be delivered soon. * `FAILED` - Delivery of reward failed (e.g. email bounced). * `SUCCEEDED` - Reward was successfully delivered (email or text message delivered or reward link active). * `PENDING` - Delivery is pending but not yet scheduled. ")
     __properties: ClassVar[List[str]] = ["method", "status"]
 
-    @field_validator('method')
-    def method_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['EMAIL', 'LINK', 'PHONE']):
-            raise ValueError("must be one of enum values ('EMAIL', 'LINK', 'PHONE')")
-        return value
-
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['SCHEDULED', 'FAILED', 'SUCCEEDED', 'PENDING']):
-            raise ValueError("must be one of enum values ('SCHEDULED', 'FAILED', 'SUCCEEDED', 'PENDING')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/single_reward_order_reward_delivery.py
+++ b/tremendous/models/single_reward_order_reward_delivery.py
@@ -32,16 +32,6 @@ class SingleRewardOrderRewardDelivery(BaseModel):
     meta: Optional[SingleRewardOrderRewardDeliveryMeta] = None
     __properties: ClassVar[List[str]] = ["method", "meta"]
 
-    @field_validator('method')
-    def method_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['EMAIL', 'LINK', 'PHONE']):
-            raise ValueError("must be one of enum values ('EMAIL', 'LINK', 'PHONE')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/single_reward_order_with_link_order.py
+++ b/tremendous/models/single_reward_order_with_link_order.py
@@ -59,23 +59,6 @@ class SingleRewardOrderWithLinkOrder(BaseModel):
             raise ValueError(r"must validate the regular expression /[A-Z0-9]{4,20}/")
         return value
 
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT']):
-            raise ValueError("must be one of enum values ('CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT')")
-        return value
-
-    @field_validator('channel')
-    def channel_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO']):
-            raise ValueError("must be one of enum values ('UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/single_reward_order_without_link_order.py
+++ b/tremendous/models/single_reward_order_without_link_order.py
@@ -59,23 +59,6 @@ class SingleRewardOrderWithoutLinkOrder(BaseModel):
             raise ValueError(r"must validate the regular expression /[A-Z0-9]{4,20}/")
         return value
 
-    @field_validator('status')
-    def status_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT']):
-            raise ValueError("must be one of enum values ('CANCELED', 'OPEN', 'EXECUTED', 'FAILED', 'PENDING APPROVAL', 'PENDING INTERNAL PAYMENT APPROVAL', 'PENDING SETTLEMENT')")
-        return value
-
-    @field_validator('channel')
-    def channel_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO']):
-            raise ValueError("must be one of enum values ('UI', 'API', 'EMBED', 'DECIPHER', 'QUALTRICS', 'TYPEFORM', 'SURVEY MONKEY', 'YOTPO')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/update_campaign.py
+++ b/tremendous/models/update_campaign.py
@@ -51,16 +51,6 @@ class UpdateCampaign(BaseModel):
             raise ValueError(r"must validate the regular expression /[A-Z0-9]{4,20}/")
         return value
 
-    @field_validator('fee_charged_to')
-    def fee_charged_to_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['SENDER', 'RECIPIENT']):
-            raise ValueError("must be one of enum values ('SENDER', 'RECIPIENT')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/update_campaign_request.py
+++ b/tremendous/models/update_campaign_request.py
@@ -40,16 +40,6 @@ class UpdateCampaignRequest(BaseModel):
     email_style: Optional[ListCampaigns200ResponseCampaignsInnerEmailStyle] = None
     __properties: ClassVar[List[str]] = ["name", "description", "products", "fee_charged_to", "auto_add_product_rule", "webpage_style", "email_style"]
 
-    @field_validator('fee_charged_to')
-    def fee_charged_to_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in set(['SENDER', 'RECIPIENT']):
-            raise ValueError("must be one of enum values ('SENDER', 'RECIPIENT')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/tremendous/models/update_fraud_rule_list_request.py
+++ b/tremendous/models/update_fraud_rule_list_request.py
@@ -32,13 +32,6 @@ class UpdateFraudRuleListRequest(BaseModel):
     config: UpdateFraudRuleListRequestConfig
     __properties: ClassVar[List[str]] = ["operation", "config"]
 
-    @field_validator('operation')
-    def operation_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['add', 'remove']):
-            raise ValueError("must be one of enum values ('add', 'remove')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,


### PR DESCRIPTION
Deserialization runs pydantic field validators that check enum membership, so whenever the API adds an enum value (product categories, fraud reasons, statuses — most releases do), previously released versions of this package start raising `ValidationError` mid-parse. Fixes #129, which #130 also proposed addressing via a full template copy; this uses a small patch on top of the patch-based generation from #131 instead. The same fix already landed in the ruby SDK (tremendous-rewards/tremendous-ruby#151).

The enum membership validators are no longer generated: unknown values are accepted and preserved as-is, while type checks and required/None enforcement still come from pydantic itself. The regenerated models are pure validator deletions (68 files, −1,014 lines).

Includes an offline test (`test/test_enum_tolerance.py`) that parses canned dicts and needs no sandbox credentials.

Stacked on #131.